### PR TITLE
fix: add Python build detection, correct stale /opsx:new references

### DIFF
--- a/assets/skills-zh/comet-build/SKILL.md
+++ b/assets/skills-zh/comet-build/SKILL.md
@@ -142,7 +142,7 @@ bash "$COMET_STATE" set <name> build_mode direct
 |------|---------|------|
 | 小 | 遗漏验收场景、边界条件 | 直接编辑 delta spec + design.md，追加 tasks.md 任务 |
 | 中 | 接口变更、新增组件、数据流变化 | 重新 `superpowers:brainstorming` 更新 Design Doc + delta spec |
-| 大 | 全新 capability 需求 | `/opsx:new` 创建独立 change |
+| 大 | 全新 capability 需求 | `/comet-open` 创建独立 change |
 
 **50% 阈值判定**：以 tasks.md 初始任务总数为基准，若新增任务数超过该总数的一半，视为超出原计划范围，应考虑拆分为新 change。
 

--- a/assets/skills-zh/comet/SKILL.md
+++ b/assets/skills-zh/comet/SKILL.md
@@ -41,9 +41,9 @@ agent 做决策只需读本节，参考附录按需查阅。
 | 多个 | `/comet`（无描述） | → 列出清单让用户选择 |
 
 <IMPORTANT>
-当用户选择「创建新变更」时，**必须调用 `/comet-open`**（禁止直接调用 `/opsx:new`）。
-`/comet-open` 负责完整双初始化：OpenSpec artifacts（由内部 `/opsx:new` 创建）+ `.comet.yaml` 状态文件。
-直接调用 `/opsx:new` 会缺失 `.comet.yaml`，导致后续阶段判定失败。
+当用户选择「创建新变更」时，**必须调用 `/comet-open`**（禁止直接调用 `openspec-new-change` 或 `openspec-propose` skill）。
+`/comet-open` 负责完整双初始化：OpenSpec artifacts（由内部 `openspec-new-change` 或 `openspec-propose` skill 创建）+ `.comet.yaml` 状态文件。
+直接调用 openspec skill 会缺失 `.comet.yaml`，导致后续阶段判定失败。
 </IMPORTANT>
 
 **Step 1: 读取 `.comet.yaml` 状态元数据**

--- a/assets/skills/comet-build/SKILL.md
+++ b/assets/skills/comet-build/SKILL.md
@@ -142,7 +142,7 @@ When the initial spec is found incomplete during implementation, handle by scale
 |------|-------------------|----------|
 | Small | Missing acceptance scenarios, edge cases | Directly edit delta spec + design.md, append tasks.md tasks |
 | Medium | Interface changes, new components, data flow changes | Re-run `superpowers:brainstorming` to update Design Doc + delta spec |
-| Large | Brand-new capability requirements | `/opsx:new` to create independent change |
+| Large | Brand-new capability requirements | `/comet-open` to create independent change |
 
 **50% Threshold Determination**: Using initial task count in tasks.md as baseline, if new tasks exceed half of that total, it's considered outside original plan scope, should consider splitting into new change.
 

--- a/assets/skills/comet/SKILL.md
+++ b/assets/skills/comet/SKILL.md
@@ -35,9 +35,9 @@ Agents need only read this section for decision-making. Refer to the Reference A
 | Multiple | `/comet` with no description | → List changes for user selection |
 
 <IMPORTANT>
-When the user chooses "create a new change", **must invoke `/comet-open`**. Do not call `/opsx:new` directly.
-`/comet-open` performs dual initialization: OpenSpec artifacts plus `.comet.yaml` state.
-Calling `/opsx:new` directly leaves `.comet.yaml` missing and breaks later phase detection.
+When the user chooses "create a new change", **must invoke `/comet-open`**. Do not call `openspec-new-change` or `openspec-propose` skill directly.
+`/comet-open` performs dual initialization: OpenSpec artifacts (via `openspec-new-change` or `openspec-propose` skill) plus `.comet.yaml` state.
+Calling openspec skills directly leaves `.comet.yaml` missing and breaks later phase detection.
 </IMPORTANT>
 
 **Preset detection**:

--- a/assets/skills/comet/scripts/comet-guard.sh
+++ b/assets/skills/comet/scripts/comet-guard.sh
@@ -276,12 +276,14 @@ build_passes() {
     cargo build
     return $?
   fi
-  # Python project detection (compileall checks syntax + import resolution)
-  if command -v python3 >/dev/null 2>&1 || command -v python >/dev/null 2>&1; then
-    local py_cmd
-    py_cmd="$(command -v python3 >/dev/null 2>&1 && echo 'python3' || echo 'python')"
-    "$py_cmd" -m compileall . -q
-    return $?
+  # Python project detection: require a project marker to avoid false positives
+  if [ -f "pyproject.toml" ] || [ -f "setup.py" ] || [ -f "setup.cfg" ] || [ -f "requirements.txt" ]; then
+    if command -v python3 >/dev/null 2>&1 || command -v python >/dev/null 2>&1; then
+      local py_cmd
+      py_cmd="$(command -v python3 >/dev/null 2>&1 && echo 'python3' || echo 'python')"
+      "$py_cmd" -m compileall . -q
+      return $?
+    fi
   fi
   return 1
 }

--- a/assets/skills/comet/scripts/comet-guard.sh
+++ b/assets/skills/comet/scripts/comet-guard.sh
@@ -276,6 +276,13 @@ build_passes() {
     cargo build
     return $?
   fi
+  # Python project detection (compileall checks syntax + import resolution)
+  if command -v python3 >/dev/null 2>&1 || command -v python >/dev/null 2>&1; then
+    local py_cmd
+    py_cmd="$(command -v python3 >/dev/null 2>&1 && echo 'python3' || echo 'python')"
+    "$py_cmd" -m compileall . -q
+    return $?
+  fi
   return 1
 }
 


### PR DESCRIPTION
## Summary

Two fixes from real-world usage:

### 1. Python project build detection (scripts/comet-guard.sh)

`build_passes()` currently only recognizes JS (package.json), Java (pom.xml), and Rust (Cargo.toml) projects. Python projects always fail the guard check unless `build_command` is manually configured.

This PR adds Python detection via `python -m compileall . -q`, which checks both syntax and import resolution (unlike `py_compile` which only checks syntax).

### 2. Stale `/opsx:new` references

`/opsx:new` no longer exists as an installable workflow in openspec v1.3.1. Updated all references across EN and ZH docs to point to the actual skill names used by comet-open (`openspec-new-change` / `openspec-propose`).

### Files changed

| File | Change |
|------|--------|
| `assets/skills/comet/scripts/comet-guard.sh` | Add Python detection in `build_passes()` |
| `assets/skills/comet/SKILL.md` | `/opsx:new` → `openspec-new-change` / `openspec-propose` skill |
| `assets/skills-zh/comet/SKILL.md` | Same (ZH) |
| `assets/skills/comet-build/SKILL.md` | `/opsx:new` → `/comet-open` |
| `assets/skills-zh/comet-build/SKILL.md` | Same (ZH) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)