### PR TITLE
fix: ensure all OpenSpec workflows install regardless of user config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to @rpamis/comet will be documented in this file.
 
 ### Fixed
 
-- **OpenSpec all-workflows installation**: `comet init` now writes the all-workflows config directly to the platform-specific default config path (`%APPDATA%\openspec\` on Windows, `~/.config/openspec/` on macOS/Linux) in addition to the `XDG_CONFIG_HOME` env override, ensuring all 11 OpenSpec workflows are always installed regardless of the user's previous OpenSpec config state.
+- **OpenSpec all-workflows installation**: `comet init` now writes the all-workflows config directly to the platform-specific default config path (`%APPDATA%\openspec\` on Windows, `$XDG_CONFIG_HOME/openspec/` on macOS/Linux when set, otherwise `~/.config/openspec/`) in addition to the isolated `XDG_CONFIG_HOME` env override, ensuring all 11 OpenSpec workflows are always installed regardless of the user's previous OpenSpec config state.
 
 ## What's Changed [0.3.2] - 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to @rpamis/comet will be documented in this file.
 
+## What's Changed [0.3.3] - 2026-05-27
+
+### Fixed
+
+- **OpenSpec all-workflows installation**: `comet init` now writes the all-workflows config directly to the platform-specific default config path (`%APPDATA%\openspec\` on Windows, `~/.config/openspec/` on macOS/Linux) in addition to the `XDG_CONFIG_HOME` env override, ensuring all 11 OpenSpec workflows are always installed regardless of the user's previous OpenSpec config state.
+
 ## What's Changed [0.3.2] - 2026-05-27
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rpamis/comet",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rpamis/comet",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rpamis/comet",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "OpenSpec + Superpowers dual-star development workflow",
   "keywords": [
     "comet",

--- a/src/core/openspec.ts
+++ b/src/core/openspec.ts
@@ -40,25 +40,40 @@ function buildOpenSpecInitCommand(
   return `openspec init ${quoteShellArg(targetPath, platform)} --tools ${quoteShellArg(toolIds.join(','), platform)} --profile custom`;
 }
 
+const ALL_WORKFLOWS_CONFIG =
+  JSON.stringify(
+    {
+      featureFlags: {},
+      profile: 'custom',
+      delivery: 'both',
+      workflows: [...ALL_OPENSPEC_WORKFLOWS],
+    },
+    null,
+    2,
+  ) + '\n';
+
+function getOpenSpecDefaultConfigDir(): string {
+  const platform = os.platform();
+  if (platform === 'win32') {
+    const appData = process.env.APPDATA;
+    if (appData) {
+      return path.join(appData, 'openspec');
+    }
+    return path.join(os.homedir(), 'AppData', 'Roaming', 'openspec');
+  }
+  return path.join(os.homedir(), '.config', 'openspec');
+}
+
+function getOpenSpecDefaultConfigPath(): string {
+  return path.join(getOpenSpecDefaultConfigDir(), 'config.json');
+}
+
 function createOpenSpecAllWorkflowsEnv(): { env: NodeJS.ProcessEnv; configHome: string } {
   const configHome = fs.mkdtempSync(path.join(os.tmpdir(), 'comet-openspec-profile-'));
   try {
     const openspecConfigDir = path.join(configHome, 'openspec');
     fs.mkdirSync(openspecConfigDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(openspecConfigDir, 'config.json'),
-      JSON.stringify(
-        {
-          featureFlags: {},
-          profile: 'custom',
-          delivery: 'both',
-          workflows: [...ALL_OPENSPEC_WORKFLOWS],
-        },
-        null,
-        2,
-      ) + '\n',
-      'utf-8',
-    );
+    fs.writeFileSync(path.join(openspecConfigDir, 'config.json'), ALL_WORKFLOWS_CONFIG, 'utf-8');
 
     return {
       configHome,
@@ -70,6 +85,50 @@ function createOpenSpecAllWorkflowsEnv(): { env: NodeJS.ProcessEnv; configHome: 
   } catch (error) {
     fs.rmSync(configHome, { recursive: true, force: true });
     throw error;
+  }
+}
+
+interface ConfigBackup {
+  configPath: string;
+  backupPath: string;
+  hadExisting: boolean;
+}
+
+function writeAllWorkflowsToDefaultConfig(): ConfigBackup | null {
+  const configPath = getOpenSpecDefaultConfigPath();
+  const backupPath = configPath + '.comet-backup';
+
+  try {
+    const hadExisting = fs.existsSync(configPath);
+    if (hadExisting) {
+      fs.copyFileSync(configPath, backupPath);
+    }
+
+    const configDir = path.dirname(configPath);
+    if (!fs.existsSync(configDir)) {
+      fs.mkdirSync(configDir, { recursive: true });
+    }
+    fs.writeFileSync(configPath, ALL_WORKFLOWS_CONFIG, 'utf-8');
+
+    return { configPath, backupPath, hadExisting };
+  } catch {
+    return null;
+  }
+}
+
+function restoreDefaultConfig(backup: ConfigBackup | null): void {
+  if (!backup) return;
+  try {
+    if (backup.hadExisting) {
+      fs.copyFileSync(backup.backupPath, backup.configPath);
+      fs.unlinkSync(backup.backupPath);
+    } else {
+      if (fs.existsSync(backup.configPath)) {
+        fs.unlinkSync(backup.configPath);
+      }
+    }
+  } catch {
+    // Best-effort restore
   }
 }
 
@@ -122,9 +181,13 @@ async function installOpenSpec(
   }
 
   let configHome: string | undefined;
+  let configBackup: ConfigBackup | null = null;
   try {
     const openspecEnv = createOpenSpecAllWorkflowsEnv();
     configHome = openspecEnv.configHome;
+
+    configBackup = writeAllWorkflowsToDefaultConfig();
+
     execSync(buildOpenSpecInitCommand(projectPath, toolIds, scope), {
       cwd: projectPath,
       env: openspecEnv.env,
@@ -137,6 +200,7 @@ async function installOpenSpec(
     printCommandErrorDetails(error);
     return 'failed';
   } finally {
+    restoreDefaultConfig(configBackup);
     if (configHome) {
       fs.rmSync(configHome, { recursive: true, force: true });
     }

--- a/src/core/openspec.ts
+++ b/src/core/openspec.ts
@@ -61,6 +61,10 @@ function getOpenSpecDefaultConfigDir(): string {
     }
     return path.join(os.homedir(), 'AppData', 'Roaming', 'openspec');
   }
+  const xdgConfig = process.env.XDG_CONFIG_HOME;
+  if (xdgConfig) {
+    return path.join(xdgConfig, 'openspec');
+  }
   return path.join(os.homedir(), '.config', 'openspec');
 }
 
@@ -97,9 +101,10 @@ interface ConfigBackup {
 function writeAllWorkflowsToDefaultConfig(): ConfigBackup | null {
   const configPath = getOpenSpecDefaultConfigPath();
   const backupPath = configPath + '.comet-backup';
+  let hadExisting = false;
 
   try {
-    const hadExisting = fs.existsSync(configPath);
+    hadExisting = fs.existsSync(configPath);
     if (hadExisting) {
       fs.copyFileSync(configPath, backupPath);
     }
@@ -112,6 +117,13 @@ function writeAllWorkflowsToDefaultConfig(): ConfigBackup | null {
 
     return { configPath, backupPath, hadExisting };
   } catch {
+    if (hadExisting) {
+      try {
+        fs.unlinkSync(backupPath);
+      } catch {
+        // Best-effort cleanup
+      }
+    }
     return null;
   }
 }

--- a/test/ts/openspec.test.ts
+++ b/test/ts/openspec.test.ts
@@ -19,6 +19,7 @@ describe('openspec', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   describe('isCommandAvailable', () => {
@@ -153,6 +154,52 @@ describe('openspec', () => {
         'verify',
         'onboard',
       ]);
+    });
+
+    it('writes the default OpenSpec config under XDG_CONFIG_HOME on non-Windows platforms', async () => {
+      mockedExecSync.mockReturnValueOnce(Buffer.from('/usr/bin/openspec'));
+      mockedExecSync.mockReturnValueOnce(Buffer.from('ok'));
+      vi.spyOn(os, 'platform').mockReturnValue('linux');
+      const xdgConfigHome = fs.mkdtempSync(path.join(os.tmpdir(), 'comet-openspec-xdg-'));
+      vi.stubEnv('XDG_CONFIG_HOME', xdgConfigHome);
+      const writeSpy = vi.spyOn(fs, 'writeFileSync');
+
+      const { installOpenSpec } = await import('../../src/core/openspec.js');
+      const result = await installOpenSpec('/tmp/test', ['claude'], 'project');
+
+      expect(result).toBe('installed');
+      expect(
+        writeSpy.mock.calls.some(
+          ([file]) => file === path.join(xdgConfigHome, 'openspec', 'config.json'),
+        ),
+      ).toBe(true);
+    });
+
+    it('removes a default OpenSpec config backup when writing the replacement config fails', async () => {
+      mockedExecSync.mockReturnValueOnce(Buffer.from('/usr/bin/openspec'));
+      mockedExecSync.mockReturnValueOnce(Buffer.from('ok'));
+      vi.spyOn(os, 'platform').mockReturnValue('linux');
+      const xdgConfigHome = fs.mkdtempSync(path.join(os.tmpdir(), 'comet-openspec-backup-'));
+      vi.stubEnv('XDG_CONFIG_HOME', xdgConfigHome);
+      const configDir = path.join(xdgConfigHome, 'openspec');
+      const configPath = path.join(configDir, 'config.json');
+      const backupPath = configPath + '.comet-backup';
+      fs.mkdirSync(configDir, { recursive: true });
+      fs.writeFileSync(configPath, '{"existing":true}\n', 'utf-8');
+      const originalWriteFileSync = fs.writeFileSync;
+      vi.spyOn(fs, 'writeFileSync').mockImplementation((file, data, options) => {
+        if (file === configPath) {
+          throw new Error('default config write failed');
+        }
+        return originalWriteFileSync(file, data, options);
+      });
+
+      const { installOpenSpec } = await import('../../src/core/openspec.js');
+      const result = await installOpenSpec('/tmp/test', ['claude'], 'project');
+
+      expect(result).toBe('installed');
+      expect(fs.existsSync(backupPath)).toBe(false);
+      expect(fs.readFileSync(configPath, 'utf-8')).toBe('{"existing":true}\n');
     });
 
     it('cleans up the temporary OpenSpec profile directory if config creation fails', async () => {


### PR DESCRIPTION
…state

Write the all-workflows config to the platform-specific default config path (%APPDATA%\openspec\ on Windows, ~/.config/openspec/ elsewhere) in addition to the XDG_CONFIG_HOME env override, so comet init always installs all 11 OpenSpec skills even on fresh installs or when the user has a partial config.

## ✨ Summary

<!-- What changed, and why? Link related issues when available. -->

## 🎯 Scope

<!-- Check all areas touched by this PR. -->

- [ ] CLI commands (`init`, `status`, `doctor`, `update`)
- [ ] Core installer / platform detection
- [ ] Comet skills (`assets/skills/`, `assets/skills-zh/`)
- [ ] Comet shell scripts (`assets/skills/comet/scripts/`)
- [ ] Tests / CI
- [ ] Documentation / changelog
- [ ] Other:

## 🧪 Testing

<!-- List the commands you ran and summarize the result. -->

- [ ] `pnpm build`
- [ ] `pnpm lint`
- [ ] `pnpm format:check`
- [ ] `pnpm test`
- [ ] `pnpm test -- test/ts/comet-scripts.test.ts`
- [ ] `pnpm test:shell`
- [ ] Not run:

## ✅ Checklist

- [ ] PR title follows Conventional Commits, for example `fix: handle project-scope init`
- [ ] User-facing behavior is documented in `README.md`, `README-zh.md`, or `CONTRIBUTING.md`
- [ ] `CHANGELOG.md` is updated when behavior changes
- [ ] Skill changes were made in Chinese first when applicable, then synced to English
- [ ] New scripts are included in `assets/manifest.json` and relevant tests
- [ ] Shell scripts remain portable across macOS, Linux, and Windows Git Bash
- [ ] No unrelated generated files or local artifacts are included

## 👀 Notes for Reviewers

<!-- Anything reviewers should pay special attention to? -->
