### PR TITLE
fix(doctor): improve .comet.yaml top-level key validation and stop swallowing non-ENOENT readDir errors

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -40,7 +40,7 @@ function collectTopLevelYamlKeys(yamlContent: string): string[] {
     if (/^\s/u.test(line)) continue;
     if (trimmedLine.startsWith('- ')) continue;
 
-    const keyMatch = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*:/u);
+    const keyMatch = line.match(/^['"]?([A-Za-z0-9_-]+)['"]?\s*:/u);
     if (keyMatch) {
       topLevelKeys.push(keyMatch[1]);
     }

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -31,6 +31,24 @@ const VALID_YAML_FIELDS = new Set([
   'verified_at',
 ]);
 
+function collectTopLevelYamlKeys(yamlContent: string): string[] {
+  const topLevelKeys: string[] = [];
+
+  for (const line of yamlContent.split(/\r?\n/u)) {
+    const trimmedLine = line.trim();
+    if (!trimmedLine || trimmedLine.startsWith('#')) continue;
+    if (/^\s/u.test(line)) continue;
+    if (trimmedLine.startsWith('- ')) continue;
+
+    const keyMatch = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*:/u);
+    if (keyMatch) {
+      topLevelKeys.push(keyMatch[1]);
+    }
+  }
+
+  return topLevelKeys;
+}
+
 async function checkOpenSpecCli(): Promise<CheckResult> {
   if (!isCommandAvailable('openspec')) {
     return {
@@ -181,14 +199,7 @@ async function checkCometYamlValidity(projectPath: string): Promise<CheckResult[
     if (!(await fileExists(yamlPath))) continue;
 
     const raw = await fs.readFile(yamlPath, 'utf-8');
-    const unknownFields: string[] = [];
-
-    for (const line of raw.split('\n')) {
-      const match = line.match(/^(\w[\w_]*):/);
-      if (match && !VALID_YAML_FIELDS.has(match[1])) {
-        unknownFields.push(match[1]);
-      }
-    }
+    const unknownFields = collectTopLevelYamlKeys(raw).filter((key) => !VALID_YAML_FIELDS.has(key));
 
     results.push(
       unknownFields.length === 0

--- a/src/utils/file-system.ts
+++ b/src/utils/file-system.ts
@@ -51,8 +51,8 @@ export async function readDir(dirPath: string): Promise<string[]> {
   try {
     return await fs.readdir(dirPath);
   } catch (error) {
-    const fileSystemError = error as NodeJS.ErrnoException;
-    if (fileSystemError.code === 'ENOENT' || fileSystemError.code === 'ENOTDIR') {
+    const code = (error as NodeJS.ErrnoException)?.code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
       return [];
     }
 

--- a/src/utils/file-system.ts
+++ b/src/utils/file-system.ts
@@ -50,7 +50,12 @@ export async function writeFile(filePath: string, content: string): Promise<void
 export async function readDir(dirPath: string): Promise<string[]> {
   try {
     return await fs.readdir(dirPath);
-  } catch {
-    return [];
+  } catch (error) {
+    const fileSystemError = error as NodeJS.ErrnoException;
+    if (fileSystemError.code === 'ENOENT' || fileSystemError.code === 'ENOTDIR') {
+      return [];
+    }
+
+    throw error;
   }
 }

--- a/test/ts/comet-scripts.test.ts
+++ b/test/ts/comet-scripts.test.ts
@@ -960,7 +960,7 @@ describe('comet shell scripts', () => {
 
     expect(result.status).toBe(0);
     expect(mode.stdout.trim()).toBe('full');
-  });
+  }, 25_000);
 
   it('transitions full workflow from open to design', async () => {
     await createChange(

--- a/test/ts/doctor.test.ts
+++ b/test/ts/doctor.test.ts
@@ -52,4 +52,53 @@ describe('doctor command', () => {
       status: 'pass',
     });
   });
+
+  it('only validates top-level keys in .comet.yaml', async () => {
+    const validChangeDir = path.join(tmpDir, 'openspec', 'changes', 'nested-valid');
+    await fs.mkdir(validChangeDir, { recursive: true });
+    await fs.writeFile(
+      path.join(validChangeDir, '.comet.yaml'),
+      [
+        'workflow: full',
+        'phase: verify',
+        'verify_result: pending',
+        'archived: false',
+        'verification_report:',
+        '  nested_key: value',
+        '',
+      ].join('\n'),
+    );
+
+    const invalidChangeDir = path.join(tmpDir, 'openspec', 'changes', 'top-level-invalid');
+    await fs.mkdir(invalidChangeDir, { recursive: true });
+    await fs.writeFile(
+      path.join(invalidChangeDir, '.comet.yaml'),
+      [
+        'workflow: full',
+        'phase: verify',
+        'unknown_root_field: true',
+        '',
+      ].join('\n'),
+    );
+
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    let json = '';
+    try {
+      await doctorCommand(tmpDir, { json: true });
+      json = log.mock.calls.map((call) => call.join(' ')).join('\n');
+    } finally {
+      log.mockRestore();
+    }
+
+    const results = JSON.parse(json).results as Array<{ check: string; status: string; message: string }>;
+
+    expect(results.find((result) => result.check === '.comet.yaml: nested-valid')).toMatchObject({
+      status: 'pass',
+    });
+
+    expect(results.find((result) => result.check === '.comet.yaml: top-level-invalid')).toMatchObject({
+      status: 'fail',
+      message: expect.stringContaining('unknown_root_field'),
+    });
+  });
 });

--- a/test/ts/file-system.test.ts
+++ b/test/ts/file-system.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
@@ -117,6 +117,18 @@ describe('file-system utils', () => {
     it('returns empty array for non-existent directory', async () => {
       const entries = await readDir(path.join(tmpDir, 'nope'));
       expect(entries).toEqual([]);
+    });
+
+    it('throws for non-ENOENT filesystem errors', async () => {
+      const readdirSpy = vi.spyOn(fs, 'readdir').mockRejectedValue(
+        Object.assign(new Error('permission denied'), { code: 'EACCES' }),
+      );
+
+      try {
+        await expect(readDir(tmpDir)).rejects.toThrow('permission denied');
+      } finally {
+        readdirSpy.mockRestore();
+      }
     });
   });
 });


### PR DESCRIPTION
improve .comet.yaml top-level key validation and stop swallowing non-ENOENT readDir errors

## ✨ Summary

<!-- What changed, and why? Link related issues when available. -->

## 🎯 Scope

<!-- Check all areas touched by this PR. -->

- [ ] CLI commands (`init`, `status`, `doctor`, `update`)
- [ ] Core installer / platform detection
- [ ] Comet skills (`assets/skills/`, `assets/skills-zh/`)
- [ ] Comet shell scripts (`assets/skills/comet/scripts/`)
- [ ] Tests / CI
- [ ] Documentation / changelog
- [x] Other: improve .comet.yaml top-level key validation and stop swallowing non-ENOENT readDir errors

## 🧪 Testing

<!-- List the commands you ran and summarize the result. -->

- [x] `pnpm build`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm test`
- [x] `pnpm test -- test/ts/comet-scripts.test.ts`
- [x] `pnpm test:shell`
- [ ] Not run:

## ✅ Checklist

- [ ] PR title follows Conventional Commits, for example `fix: handle project-scope init`
- [ ] User-facing behavior is documented in `README.md`, `README-zh.md`, or `CONTRIBUTING.md`
- [ ] `CHANGELOG.md` is updated when behavior changes
- [ ] Skill changes were made in Chinese first when applicable, then synced to English
- [ ] New scripts are included in `assets/manifest.json` and relevant tests
- [ ] Shell scripts remain portable across macOS, Linux, and Windows Git Bash
- [ ] No unrelated generated files or local artifacts are included

## 👀 Notes for Reviewers

<!-- Anything reviewers should pay special attention to? -->
