### PR TITLE
feat: add lightweight verification review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to @rpamis/comet will be documented in this file.
 ### Changed
 
 - **Command execution security**: Refactored all command execution in OpenSpec and Superpowers install paths from `spawn` with shell interpretation to `execFileSync`, eliminating shell injection surface and improving cross-platform reliability (#88bf487)
+- **Lightweight verification review**: Lightweight verification now requires a scoped code review focused on correctness, security, and edge cases, adding review coverage without running full spec or design drift checks (#42)
 
 ### Fixed
 
@@ -22,6 +23,7 @@ All notable changes to @rpamis/comet will be documented in this file.
 - Added coverage for OpenCode global OpenSpec path migration, self-deletion guard, and homedir mocking
 - Added doctor tests for `.comet.yaml` top-level key validation and non-ENOENT `readDir` error propagation
 - Fixed timeout for git-based test "uses plan base-ref to scale verification"
+- Added workflow safeguard coverage for the lightweight verification code review requirement
 
 ### Docs
 

--- a/assets/skills-zh/comet-verify/SKILL.md
+++ b/assets/skills-zh/comet-verify/SKILL.md
@@ -87,8 +87,11 @@ bash "$COMET_STATE" set <change-name> verify_mode full
 3. 编译通过（执行项目对应的构建命令，如 `npm run build`、`mvn compile`、`cargo build` 等）
 4. 相关测试通过
 5. 无明显安全问题（无硬编码密钥、无新增 unsafe 操作）
+6. 简化代码审查通过：派发 code-reviewer 子 agent，只检查 correctness、安全、边界条件
 
-**通过标准**：5 项全部 OK，无 CRITICAL 问题。
+简化代码审查的输入应限定为本次改动 diff、tasks.md 和必要的测试结果；审查范围只覆盖实现正确性、安全风险和边界条件，不执行 spec 覆盖率、Design Doc 一致性或漂移检查。若审查发现 CRITICAL 或 IMPORTANT 问题，按验证失败处理并进入 Step 1b。
+
+**通过标准**：6 项全部 OK，无 CRITICAL 问题。
 
 **不通过时**：报告失败项，进入 Step 1b 的验证失败决策阻塞点。用户选择修复后，才执行以下命令记录失败并回退到 build 阶段，然后调用 `/comet-build` 修复：
 
@@ -97,12 +100,12 @@ bash "$COMET_STATE" set <change-name> verify_mode full
 bash "$COMET_STATE" transition <change-name> verify-fail
 ```
 
-**报告格式**：简表列出 5 项检查结果 + PASS/FAIL。
+**报告格式**：简表列出 6 项检查结果 + PASS/FAIL。
 
 **跳过项**（不在轻量验证中检查）：
 - spec scenario 覆盖率
 - design doc 一致性深度比对
-- code pattern consistency 建议
+- 不影响 correctness、安全、边界条件的 code pattern consistency 建议
 - delta spec 与 design doc 漂移检测
 
 ### 2b. 完整验证（大改动）

--- a/assets/skills/comet-verify/SKILL.md
+++ b/assets/skills/comet-verify/SKILL.md
@@ -87,8 +87,11 @@ When scale assessment result is "small", skip `openspec-verify-change` and direc
 3. Build passes (run project-specific build command, e.g., `npm run build`, `mvn compile`, `cargo build`, etc.)
 4. Related tests pass
 5. No obvious security issues (no hardcoded keys, no new unsafe operations)
+6. lightweight code review passes: dispatch a code-reviewer subagent that checks only correctness, security, and edge cases
 
-**Pass criteria**: All 5 items OK, no CRITICAL issues.
+The lightweight code review input should be limited to this change's diff, tasks.md, and necessary test results; the review scope covers implementation correctness, security risk, and edge cases only, and does not perform spec coverage, Design Doc consistency, or drift checks. If the review finds CRITICAL or IMPORTANT issues, treat verification as failed and enter Step 1b.
+
+**Pass criteria**: All 6 items OK, no CRITICAL issues.
 
 **When not passing**: Report failures, enter Step 1b verification failure decision blocking point. Only after user confirms fix, execute the following command to record failure and roll back to build phase, then invoke `/comet-build` to fix:
 
@@ -97,12 +100,12 @@ When scale assessment result is "small", skip `openspec-verify-change` and direc
 bash "$COMET_STATE" transition <change-name> verify-fail
 ```
 
-**Report format**: Brief table listing 5 check results + PASS/FAIL.
+**Report format**: Brief table listing 6 check results + PASS/FAIL.
 
 **Skipped items** (not checked in lightweight verification):
 - spec scenario coverage
 - design doc consistency deep comparison
-- code pattern consistency suggestions
+- code pattern consistency suggestions that do not affect correctness, security, or edge cases
 - delta spec and design doc drift detection
 
 ### 2b. Full Verification (Large Changes)

--- a/test/ts/skills.test.ts
+++ b/test/ts/skills.test.ts
@@ -245,6 +245,9 @@ describe('skills', () => {
       // MEDIUM: comet-verify Step 1b handles mixed CRITICAL/non-CRITICAL
       expect(zhVerify).toContain('CRITICAL 失败项必须修复');
       expect(zhVerify).toContain('不允许跳过修复直接全部接受');
+      expect(zhVerify).toContain('简化代码审查');
+      expect(zhVerify).toContain('只检查 correctness、安全、边界条件');
+      expect(zhVerify).toContain('不执行 spec 覆盖率、Design Doc 一致性或漂移检查');
 
       // MEDIUM: hotfix IMPORTANT covers >3-tasks comet-build decision points
       expect(zhHotfix).toContain('任务超过 3 个转入 `/comet-build` 时的工作区隔离和执行方式选择');
@@ -333,6 +336,9 @@ describe('skills', () => {
       expect(enComet).toContain('first check whether `build_mode` and `isolation` are set');
       expect(enVerify).toContain('CRITICAL failures must be fixed');
       expect(enVerify).toContain('skipping fix to accept all is not allowed');
+      expect(enVerify).toContain('lightweight code review');
+      expect(enVerify).toContain('checks only correctness, security, and edge cases');
+      expect(enVerify).toContain('does not perform spec coverage, Design Doc consistency, or drift checks');
       expect(enHotfix).toContain('workspace isolation and execution-method selection when tasks exceed 3 and transfer to `/comet-build`');
       expect(enBuild).toContain('Pause and wait for user confirmation, then must use Skill tool to load `superpowers:brainstorming`');
       expect(enBuild).toContain('must pause and wait for the user to decide whether to split into new change');


### PR DESCRIPTION
## Summary

- Require lightweight verification to include a scoped code review.
- Limit the review to correctness, security, and edge cases.
- Add workflow safeguard coverage and a changelog entry.

## Test Plan

- `npx vitest run test/ts/skills.test.ts`
- `git diff --check origin/master..HEAD`

## Notes

- Full `npx vitest run` currently fails in `test/ts/init-e2e.test.ts` because the clean-directory init fixture cannot find `.claude/skills` in the temporary home.