### PR TITLE
fix: prevent skip-all from skipping uninstalled components in comet init

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -120,13 +120,16 @@ async function promptBulkOverwriteChoice(
 function applyBulkOverwriteChoice<T extends ComponentPlan>(
   plan: T,
   choice: Exclude<BulkOverwriteChoice, 'choose'>,
+  hasExisting?: { os?: boolean; sp?: boolean; cm?: boolean },
 ): T {
   const action = choice === 'overwrite-all' ? 'overwrite' : 'skip';
+  const shouldApply = (actionState: ComponentAction, exists?: boolean) =>
+    actionState === 'install' && (hasExisting === undefined || exists === true);
   return {
     ...plan,
-    osAction: plan.osAction === 'install' ? action : plan.osAction,
-    spAction: plan.spAction === 'install' ? action : plan.spAction,
-    cmAction: plan.cmAction === 'install' ? action : plan.cmAction,
+    osAction: shouldApply(plan.osAction, hasExisting?.os) ? action : plan.osAction,
+    spAction: shouldApply(plan.spAction, hasExisting?.sp) ? action : plan.spAction,
+    cmAction: shouldApply(plan.cmAction, hasExisting?.cm) ? action : plan.cmAction,
   };
 }
 
@@ -247,6 +250,7 @@ export async function initCommand(targetPath: string, options: InitOptions = {})
           ({ osAction, spAction, cmAction } = applyBulkOverwriteChoice(
             { osAction, spAction, cmAction },
             bulkChoice,
+            { os: hasOS, sp: hasSP, cm: hasCM },
           ));
         }
       }

--- a/test/ts/init.test.ts
+++ b/test/ts/init.test.ts
@@ -20,4 +20,64 @@ describe('init command helpers', () => {
       cmAction: 'skip',
     });
   });
+
+  it('only affects existing components when hasExisting is provided with skip-all', () => {
+    const plan = {
+      osAction: 'install' as const,
+      spAction: 'install' as const,
+      cmAction: 'install' as const,
+    };
+    const hasExisting = { os: true, sp: false, cm: true };
+
+    expect(applyBulkOverwriteChoice(plan, 'skip-all', hasExisting)).toEqual({
+      osAction: 'skip',
+      spAction: 'install',
+      cmAction: 'skip',
+    });
+  });
+
+  it('only affects existing components when hasExisting is provided with overwrite-all', () => {
+    const plan = {
+      osAction: 'install' as const,
+      spAction: 'install' as const,
+      cmAction: 'install' as const,
+    };
+    const hasExisting = { os: false, sp: true, cm: false };
+
+    expect(applyBulkOverwriteChoice(plan, 'overwrite-all', hasExisting)).toEqual({
+      osAction: 'install',
+      spAction: 'overwrite',
+      cmAction: 'install',
+    });
+  });
+
+  it('skips-all with hasExisting all false leaves all as install', () => {
+    const plan = {
+      osAction: 'install' as const,
+      spAction: 'install' as const,
+      cmAction: 'install' as const,
+    };
+    const hasExisting = { os: false, sp: false, cm: false };
+
+    expect(applyBulkOverwriteChoice(plan, 'skip-all', hasExisting)).toEqual({
+      osAction: 'install',
+      spAction: 'install',
+      cmAction: 'install',
+    });
+  });
+
+  it('does not affect non-install actions even when hasExisting is true', () => {
+    const plan = {
+      osAction: 'overwrite' as const,
+      spAction: 'skip' as const,
+      cmAction: 'install' as const,
+    };
+    const hasExisting = { os: true, sp: true, cm: true };
+
+    expect(applyBulkOverwriteChoice(plan, 'skip-all', hasExisting)).toEqual({
+      osAction: 'overwrite',
+      spAction: 'skip',
+      cmAction: 'skip',
+    });
+  });
 });


### PR DESCRIPTION
## Summary

修复 `comet init` 交互中 "Skip all existing components" 会错误跳过未安装组件（如 Comet）的问题。

## Root cause

`applyBulkOverwriteChoice` 在 "skip-all" 时，把所有值为 `'install'` 的组件都改成 `'skip'`，不区分组件是否真的已安装。未安装的组件（`hasExisting = false`）也被一并跳过。

## Fix

给 `applyBulkOverwriteChoice` 增加可选参数 `hasExisting`，批量选择只影响 `hasExisting.xxx === true` 的组件。

## Test plan

- [x] 新增 4 个单元测试覆盖 `hasExisting` 各场景
- [x] `npx vitest run test/ts/init.test.ts` 全部通过

Closes #71 