### PR TITLE
feat: Add lightweight verification review #42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to @rpamis/comet will be documented in this file.
 ### Changed
 
 - **executing-plans review gate**: When `build_mode` is `executing-plans`, the build phase now requires loading the Superpowers `requesting-code-review` skill and requesting code review at least once before the build→verify phase guard. CRITICAL findings must be fixed before verify; accepted non-CRITICAL findings must record acceptance rationale in a durable artifact. The build-exit checklist enforces this gate ([#76](https://github.com/rpamis/comet/pull/76), [#41](https://github.com/rpamis/comet/issues/41)).
+- **Lightweight verification review**: Lightweight verification now requires a scoped Superpowers `requesting-code-review` review focused on correctness, security, and edge cases, adding review coverage without running full spec or design drift checks (#42).
 - **Phase advancement vs handoff wording**: Chinese and English Comet skills now consistently distinguish guard-driven phase advancement (`--apply`, always updates `phase`) from next-skill invocation control (`auto_transition`). Open/design/build/verify/hotfix/tweak guidance now routes through `comet-state next` for auto/manual handoff.
 - **Preset continuity wording**: Hotfix and tweak guidance now explicitly documents the `auto_transition: false` exception in continuous execution mode, removing contradictory wording around "always continue" behavior.
 - **Verify hash-skip scoped to tasks.md only**: Full verification always reads `proposal.md` and `design.md` even when hash matches, ensuring goal-satisfaction and design-consistency checks have complete context.
@@ -74,6 +75,8 @@ All notable changes to @rpamis/comet will be documented in this file.
 
 - **Update JSON output for rules/hooks**: `comet update --json` now includes rules and hooks distribution results alongside skill update results, with per-target error isolation so a single platform failure doesn't break the entire update output.
 
+- **Lightweight verification consistency**: Hotfix documentation now describes the 6-item lightweight verification path, and Step 1b treats CRITICAL and IMPORTANT failures as blocking so code-review pass criteria and failure handling agree.
+
 - **Duplicate YAML fields**: `replace_yaml_field` in `comet-state.sh` now deduplicates all fields after replacement, keeping only the last occurrence of each key. Previously, multiple `cmd_set` calls for the same field (e.g., during verify-fail → re-verify cycles) could leave duplicate lines in `.comet.yaml`, confusing downstream parsers. Fixes [#77](https://github.com/rpamis/comet/issues/77).
 
 - **Hook config format**: `installClaudeCodeHooks` and `.claude/settings.local.json` now use the correct `matcher` + `hooks: [{ type, command }]` array format instead of the flat `{ matcher, command, description }` format, fixing the `/doctor` schema validation error.
@@ -97,6 +100,7 @@ All notable changes to @rpamis/comet will be documented in this file.
 - **Skill handoff wording regression update**: Updated skill-content assertions to validate next-driven handoff wording (`NEXT: auto|manual|done`) and synchronized Chinese/English expectation checks.
 - **Output language regression**: Added skill coverage that Comet propagates the triggering user request language into OpenSpec and Superpowers steps across the open, design, build, verify, hotfix, tweak, and archive skills ([#53](https://github.com/rpamis/comet/pull/53)).
 - **Review gate regression**: Added skill coverage that `executing-plans` build mode requires the `requesting-code-review` gate before the build→verify transition, plus updated init-e2e expectations ([#76](https://github.com/rpamis/comet/pull/76)).
+- **Lightweight verification review regression**: Added workflow safeguard coverage for the lightweight verification code-review requirement and hotfix documentation consistency.
 - **skip-all regression**: Added `comet init` coverage that skip-all only skips installed components and still offers uninstalled OpenSpec/Superpowers/Comet/CodeGraph components ([#73](https://github.com/rpamis/comet/pull/73)).
 - **`--hash-only` flag coverage**: New tests verify correct hash output, change-directory validation, required-file validation, and no handoff file regeneration.
 - **Context benchmark runner coverage**: New tests verify benchmark token-savings math, Codex JSONL usage/verdict parsing, and dry-run report generation without invoking Codex.

--- a/assets/skills-zh/comet-hotfix/SKILL.md
+++ b/assets/skills-zh/comet-hotfix/SKILL.md
@@ -129,7 +129,7 @@ fi
 
 **立即执行：** 使用 Skill 工具加载 `comet-verify` 技能。禁止跳过此步骤。
 
-无 delta spec 的小范围 hotfix 通常满足轻量验证条件（≤ 3 tasks、≤ 2 files），comet-verify 的规模评估会选择轻量验证路径（5 项快速检查）。若 hotfix 创建了 delta spec，则根据 comet-verify 的规模评估规则进入完整验证路径。
+无 delta spec 的小范围 hotfix 通常满足轻量验证条件（≤ 3 tasks、≤ 2 files），comet-verify 的规模评估会选择轻量验证路径（6 项快速检查，包含简化代码审查）。若 hotfix 创建了 delta spec，则根据 comet-verify 的规模评估规则进入完整验证路径。
 
 验证通过后，按 `/comet-verify` 的规则将 `.comet.yaml` 的 `verify_result` 记录为 `pass`，归档前不得跳过该状态。验证通过后仍必须进入 `/comet-archive` 的归档前最终确认，不得自动运行归档脚本。
 

--- a/assets/skills-zh/comet-verify/SKILL.md
+++ b/assets/skills-zh/comet-verify/SKILL.md
@@ -81,14 +81,14 @@ git diff --stat "$BASE_REF"...HEAD
 
 暂停时必须列出：
 - 失败项
-- 是否属于 CRITICAL（构建失败、测试失败、安全问题、核心验收场景失败）
+- 是否属于 CRITICAL 或 IMPORTANT（构建失败、测试失败、安全问题、核心验收场景失败、简化代码审查发现的正确性/安全/边界问题）
 - 推荐处理方式
 
 **不确定性原则**：无法确定严重程度时，降级处理（SUGGESTION > WARNING > CRITICAL）。仅对构建失败、测试失败、安全问题使用 CRITICAL；模糊或不确定的问题标为 WARNING 或 SUGGESTION。
 
 用户选择后按以下方式继续：
 - **全部修复**：运行 `"$COMET_BASH" "$COMET_STATE" transition <change-name> verify-fail`，然后调用 `/comet-build` 修复
-- **逐项处理**：CRITICAL 失败项必须修复；非 CRITICAL 失败项可选择接受偏差，但必须在验证报告中记录接受原因和影响范围。若存在任何 CRITICAL 失败项，不允许跳过修复直接全部接受
+- **逐项处理**：CRITICAL 或 IMPORTANT 失败项必须修复；WARNING/SUGGESTION 失败项可选择接受偏差，但必须在验证报告中记录接受原因和影响范围。若存在任何 CRITICAL 或 IMPORTANT 失败项，不允许跳过修复直接全部接受
 
 ### 2. 产物上下文加载（Hash 按需读）
 
@@ -110,15 +110,18 @@ CURRENT_HASH=$("$COMET_BASH" "$COMET_HANDOFF" <change-name> --hash-only 2>/dev/n
 
 ### 2a. 轻量验证（小改动）
 
-按以下 5 项进行检查：
+按以下 6 项进行检查：
 
 1. tasks.md 全部任务已完成 `[x]`
 2. 改动文件与 tasks.md 描述一致（`git diff --stat` / `git diff --cached --stat` / `git diff --stat <base-ref>...HEAD` 对照 tasks 内容）
 3. 编译通过（执行项目对应的构建命令，如 `npm run build`、`mvn compile`、`cargo build` 等）
 4. 相关测试通过
 5. 无明显安全问题（无硬编码密钥、无新增 unsafe 操作）
+6. 简化代码审查通过：必须使用 Skill 工具加载 Superpowers `requesting-code-review` 技能，请求只检查正确性、安全、边界条件的轻量代码审查
 
-**通过标准**：5 项全部 OK，无 CRITICAL 问题。
+简化代码审查的输入应限定为本次改动 diff、tasks.md 和必要的测试结果；审查范围只覆盖实现正确性、安全风险和边界条件，不执行 spec 覆盖率、Design Doc 一致性或漂移检查。若审查发现 CRITICAL 或 IMPORTANT 问题，按验证失败处理并进入 Step 1b。
+
+**通过标准**：6 项全部 OK，无 CRITICAL 或 IMPORTANT 问题。
 
 **不通过时**：报告失败项，进入 Step 1b 的验证失败决策阻塞点。用户选择修复后，才执行以下命令记录失败并回退到 build 阶段，然后调用 `/comet-build` 修复：
 
@@ -127,12 +130,12 @@ CURRENT_HASH=$("$COMET_BASH" "$COMET_HANDOFF" <change-name> --hash-only 2>/dev/n
 "$COMET_BASH" "$COMET_STATE" transition <change-name> verify-fail
 ```
 
-**报告格式**：简表列出 5 项检查结果 + PASS/FAIL。
+**报告格式**：简表列出 6 项检查结果 + PASS/FAIL。
 
 **跳过项**（不在轻量验证中检查）：
 - spec scenario 覆盖率
 - design doc 一致性深度比对
-- code pattern consistency 建议
+- 不影响正确性、安全、边界条件的 code pattern consistency 建议
 - delta spec 与 design doc 漂移检测
 
 ### 2b. 完整验证（大改动）

--- a/assets/skills/comet-hotfix/SKILL.md
+++ b/assets/skills/comet-hotfix/SKILL.md
@@ -129,7 +129,7 @@ Reuse `/comet-verify`, with comet-verify's scale assessment deciding lightweight
 
 **Immediately execute:** Use the Skill tool to load the `comet-verify` skill. Skipping this step is prohibited.
 
-Small-scale hotfixes without delta spec usually meet lightweight verification conditions (≤ 3 tasks, ≤ 2 files), comet-verify's scale assessment will select lightweight verification path (5 quick checks). If hotfix created delta spec, enter full verification path according to comet-verify's scale assessment rules.
+Small-scale hotfixes without delta spec usually meet lightweight verification conditions (≤ 3 tasks, ≤ 2 files), comet-verify's scale assessment will select the lightweight verification path (6 quick checks, including lightweight code review). If hotfix created delta spec, enter full verification path according to comet-verify's scale assessment rules.
 
 After verification passes, record `.comet.yaml` `verify_result` as `pass` according to `/comet-verify` rules, must not skip this status before archiving. After verification passes, still enter `/comet-archive`'s final archive confirmation; do not automatically run the archive script.
 

--- a/assets/skills/comet-verify/SKILL.md
+++ b/assets/skills/comet-verify/SKILL.md
@@ -81,14 +81,14 @@ When verification does not pass, **must use the current platform's available use
 
 When pausing, must list:
 - Failed items
-- Whether CRITICAL (build failure, test failure, security issues, core acceptance scenario failure)
+- Whether CRITICAL or IMPORTANT (build failure, test failure, security issues, core acceptance scenario failure, lightweight code review correctness/security/edge-case issue)
 - Recommended handling approach
 
 **Uncertainty principle**: When severity is unclear, downgrade (SUGGESTION > WARNING > CRITICAL). Only use CRITICAL for build failures, test failures, and security issues; ambiguous or uncertain issues should be WARNING or SUGGESTION.
 
 After user selection, continue as follows:
 - **Fix all**: Run `"$COMET_BASH" "$COMET_STATE" transition <change-name> verify-fail`, then invoke `/comet-build` to fix
-- **Handle item by item**: CRITICAL failures must be fixed; non-CRITICAL failures may choose to accept deviation, but must record acceptance reason and impact scope in verification report. If any CRITICAL failure exists, skipping fix to accept all is not allowed
+- **Handle item by item**: CRITICAL or IMPORTANT failures must be fixed; WARNING/SUGGESTION failures may choose to accept deviation, but must record acceptance reason and impact scope in verification report. If any CRITICAL or IMPORTANT failure exists, skipping fix to accept all is not allowed
 
 **Retry limit**: After 3 consecutive verify-fail cycles, on the 4th failure the agent must not automatically choose to continue fixing; **must use the current platform's available user input/confirmation mechanism to pause** with only two options: "Accept all deviations and record" or "Continue fixing", for the user to explicitly decide.
 
@@ -112,15 +112,18 @@ After the skill loads, follow the `verify_mode` branch:
 
 ### 2a. Lightweight Verification (Small Changes)
 
-Run these 5 checks:
+Run these 6 checks:
 
 1. All tasks.md tasks completed `[x]`
 2. Changed files match tasks.md descriptions (`git diff --stat` / `git diff --cached --stat` / `git diff --stat <base-ref>...HEAD` compared against tasks content)
 3. Build passes (run project-specific build command, e.g., `npm run build`, `mvn compile`, `cargo build`, etc.)
 4. Related tests pass
 5. No obvious security issues (no hardcoded keys, no new unsafe operations)
+6. Lightweight code review passes: use the Skill tool to load the Superpowers `requesting-code-review` skill and request a lightweight review that checks only correctness, security, and edge cases
 
-**Pass criteria**: All 5 items OK, no CRITICAL issues.
+The lightweight code review input should be limited to this change's diff, tasks.md, and necessary test results; the review scope covers implementation correctness, security risk, and edge cases only, and does not perform spec coverage, Design Doc consistency, or drift checks. If the review finds CRITICAL or IMPORTANT issues, treat verification as failed and enter Step 1b.
+
+**Pass criteria**: All 6 items OK, no CRITICAL or IMPORTANT issues.
 
 **When not passing**: Report failures, enter Step 1b verification failure decision blocking point. Only after user confirms fix, execute the following command to record failure and roll back to build phase, then invoke `/comet-build` to fix:
 
@@ -129,12 +132,12 @@ Run these 5 checks:
 "$COMET_BASH" "$COMET_STATE" transition <change-name> verify-fail
 ```
 
-**Report format**: Brief table listing 5 check results + PASS/FAIL.
+**Report format**: Brief table listing 6 check results + PASS/FAIL.
 
 **Skipped items** (not checked in lightweight verification):
 - spec scenario coverage
 - design doc consistency deep comparison
-- code pattern consistency suggestions
+- code pattern consistency suggestions that do not affect correctness, security, or edge cases
 - delta spec and design doc drift detection
 
 ### 2b. Full Verification (Large Changes)

--- a/test/ts/skills.test.ts
+++ b/test/ts/skills.test.ts
@@ -321,9 +321,16 @@ describe('skills', () => {
         'CRITICAL review 发现（安全漏洞、数据丢失风险、构建/测试失败）必须先修复',
       );
 
-      // MEDIUM: comet-verify Step 1b handles mixed CRITICAL/non-CRITICAL
-      expect(zhVerify).toContain('CRITICAL 失败项必须修复');
+      // MEDIUM: comet-verify Step 1b treats CRITICAL/IMPORTANT as blocking
+      expect(zhVerify).toContain('CRITICAL 或 IMPORTANT 失败项必须修复');
       expect(zhVerify).toContain('不允许跳过修复直接全部接受');
+      expect(zhVerify).toContain('简化代码审查');
+      expect(zhVerify).toContain('必须使用 Skill 工具加载 Superpowers `requesting-code-review` 技能');
+      expect(zhVerify).toContain('只检查正确性、安全、边界条件');
+      expect(zhVerify).toContain('无 CRITICAL 或 IMPORTANT 问题');
+      expect(zhVerify).toContain('不影响正确性、安全、边界条件的 code pattern consistency 建议');
+      expect(zhVerify).toContain('不执行 spec 覆盖率、Design Doc 一致性或漂移检查');
+      expect(zhHotfix).toContain('6 项快速检查，包含简化代码审查');
 
       // MEDIUM: hotfix IMPORTANT covers >3-tasks comet-build decision points
       expect(zhHotfix).toContain('任务超过 3 个转入 `/comet-build` 时的工作区隔离和执行方式选择');
@@ -596,8 +603,18 @@ describe('skills', () => {
       expect(enBuild).toContain(
         'CRITICAL review findings (security vulnerabilities, data loss risk, build/test failures) must be fixed',
       );
-      expect(enVerify).toContain('CRITICAL failures must be fixed');
+      expect(enVerify).toContain('CRITICAL or IMPORTANT failures must be fixed');
       expect(enVerify).toContain('skipping fix to accept all is not allowed');
+      expect(enVerify).toContain('Lightweight code review');
+      expect(enVerify).toContain(
+        'use the Skill tool to load the Superpowers `requesting-code-review` skill',
+      );
+      expect(enVerify).toContain('checks only correctness, security, and edge cases');
+      expect(enVerify).toContain('no CRITICAL or IMPORTANT issues');
+      expect(enVerify).toContain(
+        'does not perform spec coverage, Design Doc consistency, or drift checks',
+      );
+      expect(enHotfix).toContain('6 quick checks, including lightweight code review');
       expect(enHotfix).toContain(
         'workspace isolation and execution-method selection when tasks exceed 3 and transfer to `/comet-build`',
       );


### PR DESCRIPTION
## Summary

- Add a sixth lightweight verification check that requires a scoped Superpowers `requesting-code-review` review.
- Limit the lightweight review to correctness, security, and edge cases while skipping spec coverage, Design Doc consistency, and drift checks.
- Sync hotfix documentation, changelog entries, and skill-content regression coverage in both Chinese and English workflows.

Fixes #42

## Validation

- `npx vitest run test/ts/skills.test.ts`
- `npx vitest run`
- `git diff --check`
- `rg -n "5 (quick checks|checks)|5 项快速检查|按以下 5 项|Run these 5 checks|Report format.*5|报告格式.*5|无 CRITICAL 问题|no CRITICAL issues" assets README.md README-zh.md test CHANGELOG.md --glob '!node_modules/**'` returned no matches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated verification workflow guidance to include a lightweight code review requirement as part of verification checks.
  * Enhanced failure reporting to categorize issues by severity (CRITICAL/IMPORTANT vs. WARNING/SUGGESTION) with specific handling requirements.
  * Clarified lightweight verification scope from 5 to 6 checks, with explicit guidance on review constraints and covered categories.
  * Updated verification continuation rules for mixed-severity failures.

* **Tests**
  * Added test coverage for new verification workflow safeguards and lightweight code review requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->