### PR TITLE
fix(openspec): retry without --profile for older openspec versions

### DIFF
--- a/src/core/openspec.ts
+++ b/src/core/openspec.ts
@@ -31,12 +31,14 @@ function buildOpenSpecInitInvocation(
   toolIds: string[],
   scope: InstallScope,
   homeDir = os.homedir(),
+  includeProfileFlag = true,
 ): { command: string; args: string[] } {
   const targetPath = scope === 'global' ? homeDir : projectPath;
-  return {
-    command: 'openspec',
-    args: ['init', targetPath, '--tools', toolIds.join(','), '--profile', 'custom'],
-  };
+  const args = ['init', targetPath, '--tools', toolIds.join(',')];
+  if (includeProfileFlag) {
+    args.push('--profile', 'custom');
+  }
+  return { command: 'openspec', args };
 }
 
 const ALL_WORKFLOWS_CONFIG =
@@ -249,18 +251,35 @@ async function installOpenSpec(
   let configBackup: ConfigBackup | null = null;
   try {
     const openspecEnv = createOpenSpecAllWorkflowsEnv();
-    const invocation = buildOpenSpecInitInvocation(projectPath, toolIds, scope);
     configHome = openspecEnv.configHome;
 
     configBackup = writeAllWorkflowsToDefaultConfig();
 
-    execFileSync(invocation.command, invocation.args, {
-      cwd: projectPath,
-      env: openspecEnv.env,
-      stdio: 'inherit',
-      timeout: 120_000,
-      shell: process.platform === 'win32',
-    });
+    const invocation = buildOpenSpecInitInvocation(projectPath, toolIds, scope);
+    try {
+      execFileSync(invocation.command, invocation.args, {
+        cwd: projectPath,
+        env: openspecEnv.env,
+        stdio: ['inherit', 'inherit', 'pipe'],
+        timeout: 120_000,
+        shell: process.platform === 'win32',
+      });
+    } catch (firstError) {
+      const stderrText = (firstError as { stderr?: Buffer }).stderr?.toString() ?? '';
+      if (stderrText.includes('unknown option') && stderrText.includes('--profile')) {
+        console.log('    OpenSpec does not support --profile flag, retrying without it...');
+        const fallbackInvocation = buildOpenSpecInitInvocation(projectPath, toolIds, scope, os.homedir(), false);
+        execFileSync(fallbackInvocation.command, fallbackInvocation.args, {
+          cwd: projectPath,
+          env: openspecEnv.env,
+          stdio: 'inherit',
+          timeout: 120_000,
+          shell: process.platform === 'win32',
+        });
+      } else {
+        throw firstError;
+      }
+    }
 
     if (scope === 'global' && toolIds.includes('opencode')) {
       migrateOpenCodeOpenSpecPaths(os.homedir());

--- a/test/ts/openspec.test.ts
+++ b/test/ts/openspec.test.ts
@@ -258,6 +258,17 @@ describe('openspec', () => {
       });
     });
 
+    it('omits --profile flag when includeProfileFlag is false', async () => {
+      const { buildOpenSpecInitInvocation } = await import('../../src/core/openspec.js');
+
+      expect(
+        buildOpenSpecInitInvocation('/tmp/project', ['claude'], 'project', '/home/user', false),
+      ).toEqual({
+        command: 'openspec',
+        args: ['init', '/tmp/project', '--tools', 'claude'],
+      });
+    });
+
     it('installs openspec CLI when not on PATH', async () => {
       // First call: isCommandAvailable fails
       mockedExecFileSync.mockImplementationOnce(() => {
@@ -286,6 +297,70 @@ describe('openspec', () => {
       const result = await installOpenSpec('/tmp/test', ['claude'], 'project');
 
       expect(result).toBe('failed');
+    });
+
+    it('retries without --profile when openspec reports unknown option in stderr', async () => {
+      // First call: isCommandAvailable
+      mockedExecFileSync.mockReturnValueOnce(Buffer.from('/usr/bin/openspec'));
+      // Second call: openspec init with --profile fails (stderr captured by pipe)
+      const profileError = new Error('Command failed: openspec init /tmp/test --tools claude --profile custom') as Error & { stderr?: Buffer };
+      profileError.stderr = Buffer.from("error: unknown option '--profile'");
+      mockedExecFileSync.mockImplementationOnce(() => {
+        throw profileError;
+      });
+      // Third call: openspec init without --profile succeeds
+      mockedExecFileSync.mockReturnValueOnce(Buffer.from('ok'));
+
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const { installOpenSpec } = await import('../../src/core/openspec.js');
+      const result = await installOpenSpec('/tmp/test', ['claude'], 'project');
+
+      expect(result).toBe('installed');
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(3);
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('retrying without it'),
+      );
+
+      // Verify the retry call did not include --profile
+      const retryArgs = mockedExecFileSync.mock.calls[2][1] as string[];
+      expect(retryArgs).not.toContain('--profile');
+
+      logSpy.mockRestore();
+    });
+
+    it('returns failed when retry without --profile also fails', async () => {
+      mockedExecFileSync.mockReturnValueOnce(Buffer.from('/usr/bin/openspec'));
+      const profileError = new Error('Command failed: openspec init ...') as Error & { stderr?: Buffer };
+      profileError.stderr = Buffer.from("error: unknown option '--profile'");
+      mockedExecFileSync.mockImplementationOnce(() => {
+        throw profileError;
+      });
+      // Retry also fails
+      mockedExecFileSync.mockImplementationOnce(() => {
+        throw new Error('retry also failed');
+      });
+
+      const { installOpenSpec } = await import('../../src/core/openspec.js');
+      const result = await installOpenSpec('/tmp/test', ['claude'], 'project');
+
+      expect(result).toBe('failed');
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(3);
+    });
+
+    it('does not retry when init fails for a non-profile reason', async () => {
+      mockedExecFileSync.mockReturnValueOnce(Buffer.from('/usr/bin/openspec'));
+      const error = new Error('Command failed: openspec init ...') as Error & { stderr?: Buffer };
+      error.stderr = Buffer.from('network timeout');
+      mockedExecFileSync.mockImplementationOnce(() => {
+        throw error;
+      });
+
+      const { installOpenSpec } = await import('../../src/core/openspec.js');
+      const result = await installOpenSpec('/tmp/test', ['claude'], 'project');
+
+      expect(result).toBe('failed');
+      // Only 2 calls: isCommandAvailable + failed init (no retry)
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(2);
     });
 
     it('shows openspec init stderr details when init throws', async () => {


### PR DESCRIPTION
## Problem

`comet init` fails with `error: unknown option '--profile'` when the user's installed version of `openspec` CLI does not support the `--profile` flag (introduced in a later version).

See: https://github.com/rpamis/comet/issues/84

## Root Cause

`buildOpenSpecInitInvocation` always passes `--profile custom` to `openspec init`. Older openspec versions don't recognize this flag and exit with an error. The `--profile` flag is actually redundant because the code already sets up a temporary `XDG_CONFIG_HOME` config file with `"profile": "custom"`.

## Fix

1. **First attempt with `--profile`**: Try the init command with `--profile custom` (for newer openspec versions that support it), capturing stderr via `stdio: ["inherit", "inherit", "pipe"]`
2. **Fallback without `--profile`**: If stderr contains `unknown option` and `--profile`, retry without the flag
3. **Non-profile errors propagate**: Other errors are not caught and propagate normally

### Changes

- `src/core/openspec.ts`: Added `includeProfileFlag` parameter to `buildOpenSpecInitInvocation`, and added stderr-based fallback logic in `installOpenSpec`
- `test/ts/openspec.test.ts`: Added 3 new tests covering retry success, retry failure, and non-profile error scenarios

## Test Plan

- [x] All existing openspec tests pass (23/23)
- [x] All existing init-e2e tests pass (8/8)
- [x] New test: retry without --profile when stderr reports unknown option
- [x] New test: retry failure returns failed
- [x] New test: non-profile errors do not trigger retry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced OpenSpec initialization with improved error detection and automatic fallback mechanisms. The setup process now intelligently identifies when configuration options are unsupported and gracefully falls back to alternative settings to retry, improving overall reliability, reducing setup failures, and enhancing compatibility across different system environments and various tool versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->