### PR TITLE
fix: detect Codex plugin superpowers

### DIFF
--- a/src/core/detect.ts
+++ b/src/core/detect.ts
@@ -14,18 +14,7 @@ const SUPERPOWERS_SKILLS = [
   'subagent-driven-development',
 ];
 
-function getBaseDir(scope: InstallScope, projectPath: string): string {
-  return scope === 'global' ? os.homedir() : projectPath;
-}
-
-/**
- * Check if superpowers are installed via Claude Code plugin system.
- * Looks in ~/.claude/plugins/cache/{marketplace}/superpowers/{version}/skills/
- */
-async function hasPluginSuperpowers(): Promise<boolean> {
-  const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
-  const pluginsCacheDir = path.join(claudeDir, 'plugins', 'cache');
-
+async function hasSuperpowersInPluginCache(pluginsCacheDir: string): Promise<boolean> {
   const marketplaceEntries = await readDir(pluginsCacheDir);
   for (const marketplace of marketplaceEntries) {
     const superpowersDir = path.join(pluginsCacheDir, marketplace, 'superpowers');
@@ -40,7 +29,35 @@ async function hasPluginSuperpowers(): Promise<boolean> {
       }
     }
   }
+
   return false;
+}
+
+function getBaseDir(scope: InstallScope, projectPath: string): string {
+  return scope === 'global' ? os.homedir() : projectPath;
+}
+
+/**
+ * Check if superpowers are installed via Claude Code plugin system.
+ * Looks in ~/.claude/plugins/cache/{marketplace}/superpowers/{version}/skills/
+ */
+async function hasPluginSuperpowers(): Promise<boolean> {
+  const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+  const pluginsCacheDir = path.join(claudeDir, 'plugins', 'cache');
+
+  return hasSuperpowersInPluginCache(pluginsCacheDir);
+}
+
+/**
+ * Check if superpowers are installed via Codex plugin system.
+ * Looks in ~/.codex/plugins/cache/{marketplace}/superpowers/{version}/skills/
+ */
+async function hasCodexPluginSuperpowers(): Promise<boolean> {
+  const codexDir =
+    process.env.CODEX_HOME || process.env.CODEX_CONFIG_DIR || path.join(os.homedir(), '.codex');
+  const pluginsCacheDir = path.join(codexDir, 'plugins', 'cache');
+
+  return hasSuperpowersInPluginCache(pluginsCacheDir);
 }
 
 /**
@@ -189,6 +206,11 @@ async function hasSkills(
     if (await hasPluginSuperpowers()) return true;
   }
 
+  // Check Codex plugin cache for plugin-installed superpowers
+  if (component === 'superpowers' && platform.id === 'codex') {
+    if (await hasCodexPluginSuperpowers()) return true;
+  }
+
   // Check OpenCode plugin system for plugin-installed superpowers
   if (component === 'superpowers' && platform.id === 'opencode') {
     if (await hasOpenCodePluginSuperpowers()) return true;
@@ -201,6 +223,7 @@ export {
   detectPlatforms,
   hasSkills,
   hasPluginSuperpowers,
+  hasCodexPluginSuperpowers,
   hasOpenCodePluginSuperpowers,
   getBaseDir,
 };

--- a/test/ts/detect.test.ts
+++ b/test/ts/detect.test.ts
@@ -245,6 +245,42 @@ describe('detect', () => {
         delete process.env.CLAUDE_CONFIG_DIR;
       }
     });
+
+    it('detects plugin-installed superpowers for codex platform', async () => {
+      const origEnv = process.env.CODEX_HOME;
+      const pluginDir = path.join(tmpDir, '.codex');
+      process.env.CODEX_HOME = pluginDir;
+
+      try {
+        const skillsDir = path.join(
+          pluginDir,
+          'plugins',
+          'cache',
+          'openai-curated',
+          'superpowers',
+          'c6ea566d',
+          'skills',
+        );
+        await fs.mkdir(skillsDir, { recursive: true });
+        await fs.mkdir(path.join(skillsDir, 'brainstorming'));
+        await fs.mkdir(path.join(skillsDir, 'using-superpowers'));
+
+        // No skills in the normal project location.
+        await fs.mkdir(path.join(tmpDir, '.codex', 'skills'), { recursive: true });
+
+        const codexPlatform = PLATFORMS.find((platform) => platform.id === 'codex');
+        expect(codexPlatform).toBeDefined();
+        if (!codexPlatform) return;
+
+        expect(await hasSkills(tmpDir, codexPlatform, 'superpowers')).toBe(true);
+      } finally {
+        if (origEnv !== undefined) {
+          process.env.CODEX_HOME = origEnv;
+        } else {
+          delete process.env.CODEX_HOME;
+        }
+      }
+    });
   });
 
   describe('hasPluginSuperpowers', () => {


### PR DESCRIPTION
## ✨ Summary

Detect Superpowers installed through the Codex plugin cache when checking the Codex platform. This lets Comet recognize plugin-provided Superpowers under `~/.codex/plugins/cache/.../superpowers/.../skills` instead of only project/global skill directories.

## 🎯 Scope

- [ ] CLI commands (`init`, `status`, `doctor`, `update`)
- [x] Core installer / platform detection
- [ ] Comet skills (`assets/skills/`, `assets/skills-zh/`)
- [ ] Comet shell scripts (`assets/skills/comet/scripts/`)
- [x] Tests / CI
- [ ] Documentation / changelog
- [ ] Other:

## 🧪 Testing

- [x] `pnpm build`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm test`
- [ ] `pnpm test -- test/ts/comet-scripts.test.ts`
- [ ] `pnpm test:shell`
- [ ] Not run:

## ✅ Checklist

- [x] PR title follows Conventional Commits, for example `fix: handle project-scope init`
- [ ] User-facing behavior is documented in `README.md`, `README-zh.md`, or `CONTRIBUTING.md`
- [ ] `CHANGELOG.md` is updated when behavior changes
- [x] Skill changes were made in Chinese first when applicable, then synced to English
- [x] New scripts are included in `assets/manifest.json` and relevant tests
- [x] Shell scripts remain portable across macOS, Linux, and Windows Git Bash
- [x] No unrelated generated files or local artifacts are included

## 👀 Notes for Reviewers

This branch intentionally includes only `src/core/detect.ts` and `test/ts/detect.test.ts`; no changelog or package/version files are included in this PR scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting superpowers installed in Codex plugin cache directories.

* **Tests**
  * Added test case verifying superpowers detection from Codex plugin installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->