### PR TITLE
feat: add init platform selected summary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,20 @@
 {
   "name": "@rpamis/comet",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rpamis/comet",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/figures": "^2.0.5",
         "@inquirer/prompts": "^8.4.3",
+        "@inquirer/type": "^4.0.5",
         "commander": "^14.0.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rpamis/comet",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Agent Skill Harness Phase-Guarded Automation From Idea To Archive",
   "keywords": [
     "comet",
@@ -63,7 +63,11 @@
     "vitest": "^4.1.6"
   },
   "dependencies": {
+    "@inquirer/ansi": "^2.0.5",
+    "@inquirer/core": "^11.1.10",
+    "@inquirer/figures": "^2.0.5",
     "@inquirer/prompts": "^8.4.3",
+    "@inquirer/type": "^4.0.5",
     "commander": "^14.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,21 @@ importers:
 
   .:
     dependencies:
+      '@inquirer/ansi':
+        specifier: ^2.0.5
+        version: 2.0.5
+      '@inquirer/core':
+        specifier: ^11.1.10
+        version: 11.1.10(@types/node@24.12.4)
+      '@inquirer/figures':
+        specifier: ^2.0.5
+        version: 2.0.5
       '@inquirer/prompts':
         specifier: ^8.4.3
         version: 8.4.3(@types/node@24.12.4)
+      '@inquirer/type':
+        specifier: ^4.0.5
+        version: 4.0.5(@types/node@24.12.4)
       commander:
         specifier: ^14.0.0
         version: 14.0.3

--- a/src/commands/i18n.ts
+++ b/src/commands/i18n.ts
@@ -9,6 +9,7 @@ export type TranslationKey =
   | 'selectPlatforms'
   | 'selectedPlatforms'
   | 'noneSelected'
+  | 'selectPlatformsRequired'
   | 'detected'
   | 'noPlatforms'
   | 'overwriteChoice'
@@ -84,6 +85,7 @@ const TRANSLATIONS: Record<Language, Record<TranslationKey, string>> = {
     selectPlatforms: 'Select platforms to set up:',
     selectedPlatforms: 'Selected:',
     noneSelected: 'none',
+    selectPlatformsRequired: 'Select at least one platform.',
     detected: 'detected',
     noPlatforms: 'No platforms selected. Exiting.',
     overwriteChoice: 'What to do?',
@@ -158,6 +160,7 @@ const TRANSLATIONS: Record<Language, Record<TranslationKey, string>> = {
     selectPlatforms: '选择要配置的平台：',
     selectedPlatforms: '已选择：',
     noneSelected: '无',
+    selectPlatformsRequired: '请至少选择一个平台。',
     detected: '已检测到',
     noPlatforms: '未选择任何平台，退出。',
     overwriteChoice: '如何处理？',

--- a/src/commands/i18n.ts
+++ b/src/commands/i18n.ts
@@ -7,6 +7,8 @@ export type TranslationKey =
   | 'scopeGlobal'
   | 'languagePrompt'
   | 'selectPlatforms'
+  | 'selectedPlatforms'
+  | 'noneSelected'
   | 'detected'
   | 'noPlatforms'
   | 'overwriteChoice'
@@ -80,6 +82,8 @@ const TRANSLATIONS: Record<Language, Record<TranslationKey, string>> = {
     scopeGlobal: 'Global (home directory)',
     languagePrompt: 'Language for Comet skills:',
     selectPlatforms: 'Select platforms to set up:',
+    selectedPlatforms: 'Selected:',
+    noneSelected: 'none',
     detected: 'detected',
     noPlatforms: 'No platforms selected. Exiting.',
     overwriteChoice: 'What to do?',
@@ -152,6 +156,8 @@ const TRANSLATIONS: Record<Language, Record<TranslationKey, string>> = {
     scopeGlobal: '全局（主目录）',
     languagePrompt: 'Comet 技能语言：',
     selectPlatforms: '选择要配置的平台：',
+    selectedPlatforms: '已选择：',
+    noneSelected: '无',
     detected: '已检测到',
     noPlatforms: '未选择任何平台，退出。',
     overwriteChoice: '如何处理？',

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -113,6 +113,7 @@ async function selectPlatforms(
     choices,
     selectedLabel: t(lang, 'selectedPlatforms'),
     emptyLabel: t(lang, 'noneSelected'),
+    requiredErrorLabel: t(lang, 'selectPlatformsRequired'),
     required: true,
   });
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import os from 'os';
 import { checkbox, select } from '@inquirer/prompts';
+import { platformSelectPrompt } from './platform-select-prompt.js';
 import { PLATFORMS, getPlatformSkillsDir, type Platform } from '../core/platforms.js';
 import { detectPlatforms, hasSkills, getBaseDir, type InstallScope } from '../core/detect.js';
 import {
@@ -97,6 +98,7 @@ async function selectPlatforms(
 ): Promise<string[]> {
   const choices = PLATFORMS.map((p) => ({
     name: `${p.name}${detected.has(p.id) ? ` (${t(lang, 'detected')})` : ''}`,
+    summaryName: p.name,
     value: p.id,
     checked: detected.has(p.id),
   }));
@@ -106,7 +108,13 @@ async function selectPlatforms(
     return selected.length > 0 ? selected : PLATFORMS.map((p) => p.id);
   }
 
-  return checkbox({ message: t(lang, 'selectPlatforms'), choices, required: true });
+  return platformSelectPrompt({
+    message: t(lang, 'selectPlatforms'),
+    choices,
+    selectedLabel: t(lang, 'selectedPlatforms'),
+    emptyLabel: t(lang, 'noneSelected'),
+    required: true,
+  });
 }
 
 async function promptOverwriteChoice(

--- a/src/commands/platform-select-prompt.ts
+++ b/src/commands/platform-select-prompt.ts
@@ -70,6 +70,7 @@ export type PlatformSelectPromptConfig<Value extends string> = {
   choices: readonly PlatformSelectChoice<Value>[];
   selectedLabel: string;
   emptyLabel: string;
+  requiredErrorLabel?: string;
   required?: boolean;
   pageSize?: number;
   theme?: PartialDeep<Theme<PlatformSelectTheme>>;
@@ -136,7 +137,7 @@ const platformSelectPromptBase = createPrompt<string[], PlatformSelectPromptConf
       if (isEnterKey(key)) {
         const selected = items.filter((item) => item.checked === true);
         if (required && selected.length === 0) {
-          setError('At least one choice must be selected');
+          setError(config.requiredErrorLabel ?? 'At least one choice must be selected');
           return;
         }
 
@@ -184,6 +185,18 @@ const platformSelectPromptBase = createPrompt<string[], PlatformSelectPromptConf
 
     const selectedNames = getSelectedChoiceNames(items);
     const message = theme.style.message(config.message, status);
+    const page = usePagination({
+      items,
+      active,
+      pageSize,
+      loop: true,
+      renderItem({ item, isActive }) {
+        const cursor = isActive ? theme.icon.cursor : ' ';
+        const checkbox = item.checked === true ? theme.icon.checked : theme.icon.unchecked;
+        const line = `${cursor}${checkbox} ${item.name}`;
+        return isActive ? theme.style.highlight(line) : line;
+      },
+    });
 
     if (status === 'done') {
       return [prefix, message, theme.style.answer(selectedNames.join(', '))].join(' ');
@@ -192,21 +205,6 @@ const platformSelectPromptBase = createPrompt<string[], PlatformSelectPromptConf
     const summary = theme.style.selectedSummary(
       renderSelectedSummaryLine(config.selectedLabel, selectedNames, config.emptyLabel),
     );
-    const page =
-      items.length === 0
-        ? ''
-        : usePagination({
-            items,
-            active,
-            pageSize,
-            loop: true,
-            renderItem({ item, isActive }) {
-              const cursor = isActive ? theme.icon.cursor : ' ';
-              const checkbox = item.checked === true ? theme.icon.checked : theme.icon.unchecked;
-              const line = `${cursor}${checkbox} ${item.name}`;
-              return isActive ? theme.style.highlight(line) : line;
-            },
-          });
     const helpLine = theme.style.keysHelpTip([
       ['↑↓', 'navigate'],
       ['space', 'select'],
@@ -218,7 +216,7 @@ const platformSelectPromptBase = createPrompt<string[], PlatformSelectPromptConf
     return `${[
       [prefix, message].join(' '),
       summary,
-      page,
+      items.length > 0 ? page : '',
       errorMsg ? theme.style.error(errorMsg) : '',
       helpLine,
     ]

--- a/src/commands/platform-select-prompt.ts
+++ b/src/commands/platform-select-prompt.ts
@@ -1,0 +1,233 @@
+import { cursorHide } from '@inquirer/ansi';
+import {
+  createPrompt,
+  isDownKey,
+  isEnterKey,
+  isSpaceKey,
+  isUpKey,
+  makeTheme,
+  useKeypress,
+  usePagination,
+  usePrefix,
+  useState,
+  type Theme,
+} from '@inquirer/core';
+import figures from '@inquirer/figures';
+import type { PartialDeep } from '@inquirer/type';
+import { styleText } from 'node:util';
+
+export type PlatformSelectChoice<Value extends string> = {
+  name: string;
+  summaryName?: string;
+  value: Value;
+  checked?: boolean;
+};
+
+type PlatformSelectTheme = {
+  icon: {
+    checked: string;
+    unchecked: string;
+    cursor: string;
+  };
+  style: {
+    selectedSummary: (text: string) => string;
+    keysHelpTip: (keys: [key: string, action: string][]) => string | undefined;
+  };
+};
+
+const platformSelectTheme: Theme<PlatformSelectTheme> = {
+  prefix: {
+    idle: styleText('cyan', '?'),
+    done: styleText('green', '✔'),
+  },
+  spinner: {
+    interval: 80,
+    frames: ['-', '\\', '|', '/'],
+  },
+  style: {
+    answer: (text: string) => styleText('cyan', text),
+    message: (text: string) => styleText('bold', text),
+    error: (text: string) => styleText('red', text),
+    defaultAnswer: (text: string) => styleText('dim', text),
+    help: (text: string) => styleText('dim', text),
+    highlight: (text: string) => styleText('cyan', text),
+    key: (text: string) => styleText('cyan', text),
+    selectedSummary: (text: string) => text,
+    keysHelpTip: (keys: [key: string, action: string][]) =>
+      keys
+        .map(([key, action]) => `${styleText('bold', key)} ${styleText('dim', action)}`)
+        .join(styleText('dim', ' • ')),
+  },
+  icon: {
+    checked: styleText('green', figures.circleFilled),
+    unchecked: figures.circle,
+    cursor: figures.pointer,
+  },
+};
+
+export type PlatformSelectPromptConfig<Value extends string> = {
+  message: string;
+  choices: readonly PlatformSelectChoice<Value>[];
+  selectedLabel: string;
+  emptyLabel: string;
+  required?: boolean;
+  pageSize?: number;
+  theme?: PartialDeep<Theme<PlatformSelectTheme>>;
+};
+
+export function getSelectedChoiceNames<Value extends string>(
+  choices: readonly PlatformSelectChoice<Value>[],
+): string[] {
+  return choices
+    .filter((choice) => choice.checked === true)
+    .map((choice) => choice.summaryName ?? choice.name);
+}
+
+export function formatSelectedSummary(
+  selectedLabel: string,
+  names: readonly string[],
+  emptyLabel: string,
+): string {
+  return `${selectedLabel} ${names.length > 0 ? names.join(', ') : emptyLabel}`;
+}
+
+export function renderSelectedSummaryLine(
+  selectedLabel: string,
+  names: readonly string[],
+  emptyLabel: string,
+): string {
+  return `  ${formatSelectedSummary(selectedLabel, names, emptyLabel)}`;
+}
+
+export function toggleChoice<Value extends string>(
+  choices: readonly PlatformSelectChoice<Value>[],
+  value: Value,
+): PlatformSelectChoice<Value>[] {
+  return choices.map((choice) =>
+    choice.value === value ? { ...choice, checked: choice.checked !== true } : choice,
+  );
+}
+
+export function selectAllChoices<Value extends string>(
+  choices: readonly PlatformSelectChoice<Value>[],
+): PlatformSelectChoice<Value>[] {
+  return choices.map((choice) => ({ ...choice, checked: true }));
+}
+
+export function invertChoices<Value extends string>(
+  choices: readonly PlatformSelectChoice<Value>[],
+): PlatformSelectChoice<Value>[] {
+  return choices.map((choice) => ({ ...choice, checked: choice.checked !== true }));
+}
+
+const platformSelectPromptBase = createPrompt<string[], PlatformSelectPromptConfig<string>>(
+  (config, done) => {
+    const theme = makeTheme(platformSelectTheme, config.theme) as Theme<PlatformSelectTheme>;
+    const { pageSize = 7, required = false } = config;
+    const [status, setStatus] = useState<'idle' | 'done'>('idle');
+    const [items, setItems] = useState<PlatformSelectChoice<string>[]>(
+      config.choices.map((choice) => ({ ...choice, checked: choice.checked === true })),
+    );
+    const [active, setActive] = useState(0);
+    const [errorMsg, setError] = useState<string>();
+    const prefix = usePrefix({ status, theme });
+
+    useKeypress((key) => {
+      if (isEnterKey(key)) {
+        const selected = items.filter((item) => item.checked === true);
+        if (required && selected.length === 0) {
+          setError('At least one choice must be selected');
+          return;
+        }
+
+        setStatus('done');
+        done(selected.map((item) => item.value));
+        return;
+      }
+
+      if (items.length === 0) {
+        return;
+      }
+
+      if (isUpKey(key) || isDownKey(key)) {
+        const offset = isUpKey(key) ? -1 : 1;
+        setActive((active + offset + items.length) % items.length);
+        setError(undefined);
+        return;
+      }
+
+      if (isSpaceKey(key)) {
+        const activeItem = items[active];
+        if (activeItem) {
+          setItems(toggleChoice(items, activeItem.value));
+          setError(undefined);
+        }
+        return;
+      }
+
+      if (key.name === 'a') {
+        const hasUnchecked = items.some((item) => item.checked !== true);
+        setItems(hasUnchecked ? selectAllChoices(items) : items.map((item) => ({ ...item, checked: false })));
+        setError(undefined);
+        return;
+      }
+
+      if (key.name === 'i') {
+        setItems(invertChoices(items));
+        setError(undefined);
+      }
+    });
+
+    const selectedNames = getSelectedChoiceNames(items);
+    const message = theme.style.message(config.message, status);
+
+    if (status === 'done') {
+      return [prefix, message, theme.style.answer(selectedNames.join(', '))].join(' ');
+    }
+
+    const summary = theme.style.selectedSummary(
+      renderSelectedSummaryLine(config.selectedLabel, selectedNames, config.emptyLabel),
+    );
+    const page =
+      items.length === 0
+        ? ''
+        : usePagination({
+            items,
+            active,
+            pageSize,
+            loop: true,
+            renderItem({ item, isActive }) {
+              const cursor = isActive ? theme.icon.cursor : ' ';
+              const checkbox = item.checked === true ? theme.icon.checked : theme.icon.unchecked;
+              const line = `${cursor}${checkbox} ${item.name}`;
+              return isActive ? theme.style.highlight(line) : line;
+            },
+          });
+    const helpLine = theme.style.keysHelpTip([
+      ['↑↓', 'navigate'],
+      ['space', 'select'],
+      ['a', 'all'],
+      ['i', 'invert'],
+      ['⏎', 'submit'],
+    ]);
+
+    return `${[
+      [prefix, message].join(' '),
+      summary,
+      page,
+      errorMsg ? theme.style.error(errorMsg) : '',
+      helpLine,
+    ]
+      .filter(Boolean)
+      .join('\n')
+      .trimEnd()}${cursorHide}`;
+  },
+);
+
+export async function platformSelectPrompt<Value extends string>(
+  config: PlatformSelectPromptConfig<Value>,
+): Promise<Value[]> {
+  return (await platformSelectPromptBase(
+    config as PlatformSelectPromptConfig<string>,
+  )) as Value[];
+}

--- a/src/commands/platform-select-prompt.ts
+++ b/src/commands/platform-select-prompt.ts
@@ -167,7 +167,11 @@ const platformSelectPromptBase = createPrompt<string[], PlatformSelectPromptConf
 
       if (key.name === 'a') {
         const hasUnchecked = items.some((item) => item.checked !== true);
-        setItems(hasUnchecked ? selectAllChoices(items) : items.map((item) => ({ ...item, checked: false })));
+        setItems(
+          hasUnchecked
+            ? selectAllChoices(items)
+            : items.map((item) => ({ ...item, checked: false })),
+        );
         setError(undefined);
         return;
       }
@@ -227,7 +231,5 @@ const platformSelectPromptBase = createPrompt<string[], PlatformSelectPromptConf
 export async function platformSelectPrompt<Value extends string>(
   config: PlatformSelectPromptConfig<Value>,
 ): Promise<Value[]> {
-  return (await platformSelectPromptBase(
-    config as PlatformSelectPromptConfig<string>,
-  )) as Value[];
+  return (await platformSelectPromptBase(config as PlatformSelectPromptConfig<string>)) as Value[];
 }

--- a/test/ts/init-e2e.test.ts
+++ b/test/ts/init-e2e.test.ts
@@ -407,6 +407,7 @@ describe('comet init E2E', () => {
         message: 'Select platforms to set up:',
         selectedLabel: 'Selected:',
         emptyLabel: 'none',
+        requiredErrorLabel: 'Select at least one platform.',
         required: true,
       }),
     );
@@ -449,6 +450,7 @@ describe('comet init E2E', () => {
         message: '选择要配置的平台：',
         selectedLabel: '已选择：',
         emptyLabel: '无',
+        requiredErrorLabel: '请至少选择一个平台。',
         required: true,
       }),
     );

--- a/test/ts/init-e2e.test.ts
+++ b/test/ts/init-e2e.test.ts
@@ -16,6 +16,10 @@ vi.mock('@inquirer/prompts', () => ({
   checkbox: vi.fn(),
 }));
 
+vi.mock('../../src/commands/platform-select-prompt.js', () => ({
+  platformSelectPrompt: vi.fn(),
+}));
+
 const manifestPath = path.resolve('assets', 'manifest.json');
 
 async function readManifest() {
@@ -382,4 +386,71 @@ describe('comet init E2E', () => {
       fs.access(path.join(tmpDir, '.kimi-code', 'skills', 'comet', 'SKILL.md')),
     ).rejects.toThrow();
   }, 20_000);
+
+  it('uses platform selection prompt with selected summary labels in English', async () => {
+    mockExternalSuccess();
+    await fs.mkdir(path.join(tmpDir, '.codex'), { recursive: true });
+
+    const { checkbox } = await import('@inquirer/prompts');
+    const { platformSelectPrompt } = await import('../../src/commands/platform-select-prompt.js');
+    vi.mocked(platformSelectPrompt).mockResolvedValue(['codex']);
+    vi.mocked(checkbox).mockResolvedValue([]);
+
+    const { initCommand } = await import('../../src/commands/init.js');
+
+    await captureJsonOutput(() =>
+      initCommand(tmpDir, { json: true, scope: 'project', language: 'en' }),
+    );
+
+    expect(platformSelectPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Select platforms to set up:',
+        selectedLabel: 'Selected:',
+        emptyLabel: 'none',
+        required: true,
+      }),
+    );
+    expect(platformSelectPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        choices: expect.arrayContaining([
+          expect.objectContaining({
+            value: 'codex',
+            name: 'Codex (detected)',
+            summaryName: 'Codex',
+            checked: true,
+          }),
+        ]),
+      }),
+    );
+    expect(checkbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Select npm dependencies to install/upgrade:',
+      }),
+    );
+  });
+
+  it('uses localized selected summary labels in Chinese', async () => {
+    mockExternalSuccess();
+    await fs.mkdir(path.join(tmpDir, '.codex'), { recursive: true });
+
+    const { checkbox } = await import('@inquirer/prompts');
+    const { platformSelectPrompt } = await import('../../src/commands/platform-select-prompt.js');
+    vi.mocked(platformSelectPrompt).mockResolvedValue(['codex']);
+    vi.mocked(checkbox).mockResolvedValue([]);
+
+    const { initCommand } = await import('../../src/commands/init.js');
+
+    await captureJsonOutput(() =>
+      initCommand(tmpDir, { json: true, scope: 'project', language: 'zh' }),
+    );
+
+    expect(platformSelectPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: '选择要配置的平台：',
+        selectedLabel: '已选择：',
+        emptyLabel: '无',
+        required: true,
+      }),
+    );
+  });
 });

--- a/test/ts/platform-select-prompt.test.ts
+++ b/test/ts/platform-select-prompt.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatSelectedSummary,
+  getSelectedChoiceNames,
+  invertChoices,
+  renderSelectedSummaryLine,
+  selectAllChoices,
+  toggleChoice,
+  type PlatformSelectChoice,
+} from '../../src/commands/platform-select-prompt.js';
+
+describe('platform select prompt state helpers', () => {
+  const choices: PlatformSelectChoice<string>[] = [
+    { name: 'Cursor', value: 'cursor' },
+    { name: 'Codex (detected)', value: 'codex', checked: true },
+    { name: 'OpenCode', value: 'opencode' },
+  ];
+
+  it('prefers summary names over display names for selected choices', () => {
+    const selectedChoices: PlatformSelectChoice<string>[] = [
+      { name: 'Cursor', value: 'cursor' },
+      { name: 'Codex (detected)', summaryName: 'Codex', value: 'codex', checked: true },
+      { name: 'OpenCode', value: 'opencode' },
+    ];
+
+    expect(getSelectedChoiceNames(selectedChoices)).toEqual(['Codex']);
+  });
+
+  it('formats selected summary with selected names', () => {
+    expect(formatSelectedSummary('Selected:', ['Codex (detected)'], 'none')).toBe(
+      'Selected: Codex (detected)',
+    );
+  });
+
+  it('formats selected summary with empty label when nothing is selected', () => {
+    expect(formatSelectedSummary('Selected:', [], 'none')).toBe('Selected: none');
+  });
+
+  it('returns checked choice names in display order', () => {
+    expect(getSelectedChoiceNames(choices)).toEqual(['Codex (detected)']);
+  });
+
+  it('toggles one choice and updates selected names', () => {
+    const next = toggleChoice(choices, 'cursor');
+    expect(getSelectedChoiceNames(next)).toEqual(['Cursor', 'Codex (detected)']);
+  });
+
+  it('selects all choices', () => {
+    const next = selectAllChoices(choices);
+    expect(getSelectedChoiceNames(next)).toEqual(['Cursor', 'Codex (detected)', 'OpenCode']);
+  });
+
+  it('inverts choices', () => {
+    const next = invertChoices(choices);
+    expect(getSelectedChoiceNames(next)).toEqual(['Cursor', 'OpenCode']);
+  });
+});
+
+describe('platform select prompt rendering helpers', () => {
+  it('renders a stable selected summary line outside choices', () => {
+    expect(renderSelectedSummaryLine('Selected:', ['Codex', 'Windsurf'], 'none')).toBe(
+      '  Selected: Codex, Windsurf',
+    );
+  });
+
+  it('renders the localized empty label when there are no selected choices', () => {
+    expect(renderSelectedSummaryLine('已选择：', [], '无')).toBe('  已选择： 无');
+  });
+});


### PR DESCRIPTION
Show the active platform selection outside the options list so detected platform labels stay concise while users still see what will be configured.

## ✨ Summary

Add display of currently selected platforms to the platform selection interface for `comet init`. The main reason for this change is that the current selection interface requires scrolling through all platforms to fully confirm which ones are selected , especially when some platforms are auto-checked because they were detected, this maks it hard to know which platforms are currently selected.

The effect of the current change is shown in the red-boxed area of the screenshot:
<img src="https://github.com/user-attachments/assets/1eb8b6d9-51f2-4efa-b9e8-fb7da96e229f" width="400" alt="Comet init change">

## 🎯 Scope

<!-- Check all areas touched by this PR. -->

- [x] CLI commands (`init`, `status`, `doctor`, `update`)
- [x] Core installer / platform detection
- [ ] Comet skills (`assets/skills/`, `assets/skills-zh/`)
- [ ] Comet shell scripts (`assets/skills/comet/scripts/`)
- [x] Tests / CI
- [ ] Documentation / changelog
- [ ] Other:

## 🧪 Testing

<!-- List the commands you ran and summarize the result. -->

- [x] `pnpm build`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm test`
- [x] `pnpm test -- test/ts/comet-scripts.test.ts`
- [x] `pnpm test:shell`
- [ ] Not run:

## ✅ Checklist

- [x] PR title follows Conventional Commits, for example `fix: handle project-scope init`
- [ ] User-facing behavior is documented in `README.md`, `README-zh.md`, or `CONTRIBUTING.md`
- [ ] `CHANGELOG.md` is updated when behavior changes
- [ ] Skill changes were made in Chinese first when applicable, then synced to English
- [ ] New scripts are included in `assets/manifest.json` and relevant tests
- [ ] Shell scripts remain portable across macOS, Linux, and Windows Git Bash
- [ ] No unrelated generated files or local artifacts are included

## 👀 Notes for Reviewers

<!-- Anything reviewers should pay special attention to? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced platform selection prompt with improved keyboard controls (Up/Down navigation, Space toggle, select all, invert selection).
  * Updated multilingual platform selection summary text for both English and Chinese.
  * Added new translation keys to support “selected platforms” messaging.
* **Dependencies**
  * Added additional Inquirer UI packages to support the enhanced terminal experience.
* **Tests**
  * Added unit tests for platform selection prompt helpers and rendering.
  * Expanded end-to-end init command coverage for English and Chinese flows.
* **Chores**
  * Bumped package version to 0.3.10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->