### PR TITLE
fix: 优化 init 部分失败的汇总展示

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to @rpamis/comet will be documented in this file.
 
 - **Per-change failure isolation in the dashboard collector**: A single malformed `.comet.yaml` or unreadable change directory no longer aborts the whole dashboard snapshot. The offending change is logged and skipped, and the rest of the sweep continues so the dashboard always renders.
 - **Defensive defaults in the Git snapshot frontend card**: A partial or stale `/api/dashboard` response (missing `recentCommits` / `dirtyFileList` / `dirtyFiles`) now renders an empty card instead of throwing a TypeError.
+- **Partial init failure summary**: `comet init` now keeps platforms with any failed component out of the final `Installed` section and names the failed component in `Failed`, so partial OpenCode setups no longer appear both installed and failed.
 
 ### Security
 

--- a/src/commands/i18n.ts
+++ b/src/commands/i18n.ts
@@ -37,6 +37,7 @@ export type TranslationKey =
   | 'installed'
   | 'skippedLabel'
   | 'failedLabel'
+  | 'failedStatus'
   | 'workingDirs'
   | 'getStarted'
   | 'getStartedComet'
@@ -113,6 +114,7 @@ const TRANSLATIONS: Record<Language, Record<TranslationKey, string>> = {
     installed: 'Installed:',
     skippedLabel: 'Skipped:',
     failedLabel: 'Failed:',
+    failedStatus: 'failed',
     workingDirs: 'Working directories: docs/superpowers/specs/, docs/superpowers/plans/',
     getStarted: 'Get started:',
     getStartedComet: '/comet "your idea"  — Start a new change with full workflow',
@@ -188,6 +190,7 @@ const TRANSLATIONS: Record<Language, Record<TranslationKey, string>> = {
     installed: '已安装：',
     skippedLabel: '已跳过：',
     failedLabel: '失败：',
+    failedStatus: '失败',
     workingDirs: '工作目录：docs/superpowers/specs/, docs/superpowers/plans/',
     getStarted: '开始使用：',
     getStartedComet: '/comet "你的想法"  — 启动完整工作流',

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -241,29 +241,32 @@ async function selectNpmDeps(
 
 function displaySummary(results: PlatformResult[], scope: InstallScope, lang: string): void {
   const scopeLabel = scope === 'global' ? os.homedir() : 'project';
+  const componentStatuses: Array<[keyof Omit<PlatformResult, 'platform'>, string]> = [
+    ['openspec', 'OpenSpec'],
+    ['superpowers', 'Superpowers'],
+    ['comet', 'Comet'],
+    ['codegraph', 'CodeGraph'],
+  ];
+  const hasFailure = (result: PlatformResult) =>
+    componentStatuses.some(([key]) => result[key] === 'failed');
+  const hasInstall = (result: PlatformResult) =>
+    componentStatuses.some(([key]) => result[key] === 'installed');
+  const failedDetails = (result: PlatformResult) =>
+    componentStatuses
+      .filter(([key]) => result[key] === 'failed')
+      .map(([, label]) => `${label} ${t(lang, 'failedStatus')}`)
+      .join(', ');
 
   console.log(`\n  ${t(lang, 'setupComplete')} (scope: ${scopeLabel})\n`);
 
-  const installed = results.filter(
-    (r) =>
-      r.openspec === 'installed' ||
-      r.superpowers === 'installed' ||
-      r.comet === 'installed' ||
-      r.codegraph === 'installed',
-  );
+  const failed = results.filter(hasFailure);
+  const installed = results.filter((r) => !hasFailure(r) && hasInstall(r));
   const skipped = results.filter(
     (r) =>
       r.openspec === 'skipped' &&
       r.superpowers === 'skipped' &&
       r.comet === 'skipped' &&
       r.codegraph === 'skipped',
-  );
-  const failed = results.filter(
-    (r) =>
-      r.openspec === 'failed' ||
-      r.superpowers === 'failed' ||
-      r.comet === 'failed' ||
-      r.codegraph === 'failed',
   );
 
   if (installed.length > 0) {
@@ -276,7 +279,10 @@ function displaySummary(results: PlatformResult[], scope: InstallScope, lang: st
     console.log(`  ${t(lang, 'skippedLabel')} ${skipped.map((r) => r.platform.name).join(', ')}`);
   }
   if (failed.length > 0) {
-    console.log(`  ${t(lang, 'failedLabel')} ${failed.map((r) => r.platform.name).join(', ')}`);
+    console.log(`  ${t(lang, 'failedLabel')}`);
+    for (const r of failed) {
+      console.log(`    ${r.platform.name} (${failedDetails(r)})`);
+    }
   }
 
   if (scope === 'project') {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -261,13 +261,7 @@ function displaySummary(results: PlatformResult[], scope: InstallScope, lang: st
 
   const failed = results.filter(hasFailure);
   const installed = results.filter((r) => !hasFailure(r) && hasInstall(r));
-  const skipped = results.filter(
-    (r) =>
-      r.openspec === 'skipped' &&
-      r.superpowers === 'skipped' &&
-      r.comet === 'skipped' &&
-      r.codegraph === 'skipped',
-  );
+  const skipped = results.filter((r) => componentStatuses.every(([key]) => r[key] === 'skipped'));
 
   if (installed.length > 0) {
     console.log(`  ${t(lang, 'installed')}`);

--- a/test/ts/init-e2e.test.ts
+++ b/test/ts/init-e2e.test.ts
@@ -20,6 +20,18 @@ vi.mock('../../src/commands/platform-select-prompt.js', () => ({
   platformSelectPrompt: vi.fn(),
 }));
 
+vi.mock('../../src/core/version.js', () => ({
+  printVersionInfo: vi.fn(async (log: (message: string) => void) => {
+    log('  Comet vtest');
+    return {
+      currentVersion: 'test',
+      latestVersion: null,
+      hasUpdate: false,
+      checked: false,
+    };
+  }),
+}));
+
 const manifestPath = path.resolve('assets', 'manifest.json');
 
 async function readManifest() {
@@ -67,6 +79,22 @@ async function captureJsonOutput(fn: () => Promise<void>): Promise<Record<string
     console.log = orig;
   }
   return JSON.parse(lines.join('\n'));
+}
+
+async function captureTextOutput(fn: () => Promise<void>): Promise<string> {
+  const lines: string[] = [];
+  const errors: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = vi.fn((...args: unknown[]) => lines.push(args.map(String).join(' ')));
+  console.error = vi.fn((...args: unknown[]) => errors.push(args.map(String).join(' ')));
+  try {
+    await fn();
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+  return [...lines, ...errors].join('\n');
 }
 
 describe('comet init E2E', () => {
@@ -301,6 +329,41 @@ describe('comet init E2E', () => {
     await expect(
       fs.access(path.join(fakeHome, '.opencode', 'skills', 'comet', 'SKILL.md')),
     ).rejects.toThrow();
+  }, 20_000);
+
+  it('summarizes partial OpenCode failures by failed component only once', async () => {
+    mockedExecFileSync.mockImplementation((command: unknown, args?: unknown) => {
+      const cmd = String(command);
+      const cmdArgs = Array.isArray(args) ? args.map((arg) => String(arg)) : [];
+
+      if ((cmd === 'which' || cmd === 'where') && cmdArgs[0] === 'openspec') {
+        return Buffer.from('/usr/bin/openspec');
+      }
+      if (cmd === 'openspec' && cmdArgs[0] === 'init') {
+        throw new Error('OpenSpec init failed for opencode');
+      }
+      if ((cmd === 'which' || cmd === 'where') && cmdArgs[0] === 'codegraph') {
+        return Buffer.from('/usr/bin/codegraph');
+      }
+      if (cmd === 'codegraph') {
+        return Buffer.from('ok');
+      }
+      if ((cmd === 'npx' || cmd === 'npx.cmd') && cmdArgs[0] === 'skills') {
+        return Buffer.from('installed');
+      }
+      return Buffer.from('');
+    });
+
+    await fs.mkdir(path.join(tmpDir, '.opencode'), { recursive: true });
+
+    const { initCommand } = await import('../../src/commands/init.js');
+    const output = await captureTextOutput(() =>
+      initCommand(tmpDir, { yes: true, language: 'en' }),
+    );
+
+    expect(output).not.toContain('Installed:\n    OpenCode -> .opencode/skills/');
+    expect(output).toContain('Failed:');
+    expect(output).toContain('OpenCode (OpenSpec failed)');
   }, 20_000);
 
   it('installs Pi global skills and commands to the Pi agent directory', async () => {

--- a/test/ts/init-e2e.test.ts
+++ b/test/ts/init-e2e.test.ts
@@ -364,6 +364,7 @@ describe('comet init E2E', () => {
     expect(output).not.toContain('Installed:\n    OpenCode -> .opencode/skills/');
     expect(output).toContain('Failed:');
     expect(output).toContain('OpenCode (OpenSpec failed)');
+    expect((output.match(/OpenCode \(OpenSpec failed\)/g) ?? [])).toHaveLength(1);
   }, 20_000);
 
   it('installs Pi global skills and commands to the Pi agent directory', async () => {


### PR DESCRIPTION
## 变更内容

- 调整 `comet init` 最终汇总的分类逻辑：只要某个平台存在失败组件，就不再把该平台列入 `Installed`。
- 在 `Failed` 汇总中显示失败组件，例如 `OpenCode (OpenSpec failed)`。
- 增加 OpenCode 部分失败场景的回归测试，覆盖 OpenSpec 初始化失败但 Comet skills 已复制成功的输出。

## 背景

此前最终汇总按组件状态分别归类，导致同一平台在部分成功、部分失败时可能同时出现在 `Installed` 和 `Failed`。新的输出保留组件级过程日志，同时让最终汇总只突出失败部分，避免误导用户认为平台整体安装成功。

## 验证

- `npx vitest run test/ts/init-e2e.test.ts test/ts/init.test.ts`
- `pnpm run build`
- `git diff --check HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `comet init` setup summary: platforms with failed components are excluded from **Installed** and failures are explicitly listed under **Failed** with per-component details.
  * Added a new localized translation key for the failure status message (`failed`) to ensure consistent messaging across supported languages.
  * Stabilized end-to-end test output by mocking version/update info and capturing combined console output, improving validation reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->