### PR TITLE
   Fixes #136 by generating quoted absolute paths for Comet hook scripts, so hook execution no longer depends on the agent’s current working directory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to @rpamis/comet will be documented in this file.
 
+## What's Changed [0.3.12] - 2026-06-27
+
+### Fixed
+
+- **Comet hook script paths**: Installed hook commands now use quoted absolute paths to the Comet hook script, so Claude-style hooks still find `comet-hook-guard.sh` when an agent is working from a nested Git submodule or split frontend/backend directory instead of the project root ([#136](https://github.com/rpamis/comet/issues/136)).
+
+### Tests
+
+- **Hook path regression coverage**: Added coverage for absolute hook command generation from nested working directories and for replacing/removing both legacy relative hooks and new absolute hook entries.
+
 ## What's Changed [0.3.11] - 2026-06-24
 
 ### Added

--- a/src/core/skills.ts
+++ b/src/core/skills.ts
@@ -395,18 +395,18 @@ async function installCometHooksForPlatform(
   try {
     switch (hookFormat) {
       case 'claude-code':
-        return installClaudeCodeHooks(platformBase, skillsDir, hooksConfig);
+        return installClaudeCodeHooks(platformBase, hooksConfig);
       case 'qwen':
       case 'qoder':
-        return installQwenStyleHooks(platformBase, skillsDir, hooksConfig, hookFormat);
+        return installQwenStyleHooks(platformBase, hooksConfig, hookFormat);
       case 'gemini':
-        return installGeminiHooks(platformBase, skillsDir, hooksConfig);
+        return installGeminiHooks(platformBase, hooksConfig);
       case 'windsurf':
-        return installWindsurfHooks(platformBase, skillsDir, hooksConfig);
+        return installWindsurfHooks(platformBase, hooksConfig);
       case 'copilot':
-        return installCopilotHooks(platformBase, skillsDir, hooksConfig);
+        return installCopilotHooks(platformBase, hooksConfig);
       case 'kiro':
-        return installKiroHooks(platformBase, skillsDir, hooksConfig);
+        return installKiroHooks(platformBase, hooksConfig);
       default:
         return { installed: false, reason: `unsupported hook format: ${hookFormat}` };
     }
@@ -415,9 +415,14 @@ async function installCometHooksForPlatform(
   }
 }
 
-/** Build the command path for a hook script given its manifest rel path and skillsDir */
-function buildHookCommand(skillsDir: string, scriptRelPath: string): string {
-  return `bash ${skillsDir}/skills/${scriptRelPath}`;
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/** Build the command path for a hook script from the platform install root. */
+function buildHookCommand(platformBase: string, scriptRelPath: string): string {
+  const scriptPath = path.resolve(platformBase, 'skills', scriptRelPath).replace(/\\/g, '/');
+  return `bash ${shellQuote(scriptPath)}`;
 }
 
 function isManagedHookCommand(command: unknown, scriptRelPaths: string[]): boolean {
@@ -425,7 +430,9 @@ function isManagedHookCommand(command: unknown, scriptRelPaths: string[]): boole
 
   const commandPath = command
     .trim()
-    .match(/^bash\s+["']?([^"'\s]+)["']?(?:\s|$)/)?.[1]
+    .match(/^bash\s+(?:"([^"]+)"|'([^']+)'|(\S+))(?:\s|$)/)
+    ?.slice(1)
+    .find((match): match is string => Boolean(match))
     ?.replace(/\\/g, '/');
   if (!commandPath) return false;
 
@@ -479,7 +486,6 @@ function asHookGroup(value: unknown): Array<Record<string, unknown>> {
  */
 async function installClaudeCodeHooks(
   platformBase: string,
-  skillsDir: string,
   hooksConfig: Record<string, HookConfig>,
 ): Promise<{ installed: boolean; reason?: string }> {
   const settingsPath = path.join(platformBase, 'settings.local.json');
@@ -493,7 +499,7 @@ async function installClaudeCodeHooks(
   // Group by matcher so hooks sharing the same matcher are merged
   const matcherGroups: Record<string, Array<{ type: string; command: string }>> = {};
   for (const [scriptRelPath, config] of Object.entries(hooksConfig)) {
-    const command = buildHookCommand(skillsDir, scriptRelPath);
+    const command = buildHookCommand(platformBase, scriptRelPath);
     if (!matcherGroups[config.matcher]) {
       matcherGroups[config.matcher] = [];
     }
@@ -529,7 +535,6 @@ async function installClaudeCodeHooks(
  */
 async function installQwenStyleHooks(
   platformBase: string,
-  skillsDir: string,
   hooksConfig: Record<string, HookConfig>,
   _hookFormat: string,
 ): Promise<{ installed: boolean; reason?: string }> {
@@ -546,7 +551,7 @@ async function installQwenStyleHooks(
     }
     matcherGroups[config.matcher].push({
       type: 'command',
-      command: buildHookCommand(skillsDir, scriptRelPath),
+      command: buildHookCommand(platformBase, scriptRelPath),
       description: config.description,
     });
   }
@@ -581,7 +586,6 @@ async function installQwenStyleHooks(
  */
 async function installGeminiHooks(
   platformBase: string,
-  skillsDir: string,
   hooksConfig: Record<string, HookConfig>,
 ): Promise<{ installed: boolean; reason?: string }> {
   const settingsPath = path.join(platformBase, 'settings.json');
@@ -596,7 +600,7 @@ async function installGeminiHooks(
       hooks: [
         {
           type: 'command',
-          command: buildHookCommand(skillsDir, scriptRelPath),
+          command: buildHookCommand(platformBase, scriptRelPath),
           name: config.description,
         },
       ],
@@ -628,7 +632,6 @@ async function installGeminiHooks(
  */
 async function installWindsurfHooks(
   platformBase: string,
-  skillsDir: string,
   hooksConfig: Record<string, HookConfig>,
 ): Promise<{ installed: boolean; reason?: string }> {
   const hooksPath = path.join(platformBase, 'hooks.json');
@@ -636,7 +639,7 @@ async function installWindsurfHooks(
   const entries: Array<{ command: string; show_output: boolean }> = [];
   for (const [scriptRelPath] of Object.entries(hooksConfig)) {
     entries.push({
-      command: buildHookCommand(skillsDir, scriptRelPath),
+      command: buildHookCommand(platformBase, scriptRelPath),
       show_output: true,
     });
   }
@@ -669,7 +672,6 @@ async function installWindsurfHooks(
  */
 async function installCopilotHooks(
   platformBase: string,
-  skillsDir: string,
   hooksConfig: Record<string, HookConfig>,
 ): Promise<{ installed: boolean; reason?: string }> {
   const hooksDir = path.join(platformBase, 'hooks');
@@ -677,9 +679,9 @@ async function installCopilotHooks(
 
   const scriptEntries: Array<{ bash: string; powershell: string }> = [];
   for (const [scriptRelPath] of Object.entries(hooksConfig)) {
-    const cmd = buildHookCommand(skillsDir, scriptRelPath);
+    const cmd = buildHookCommand(platformBase, scriptRelPath);
     // Script requires bash; PowerShell field wraps bash invocation for Windows
-    scriptEntries.push({ bash: cmd, powershell: `bash -c '${cmd}'` });
+    scriptEntries.push({ bash: cmd, powershell: `bash -c ${shellQuote(cmd)}` });
   }
 
   const hookConfig = {
@@ -700,7 +702,6 @@ async function installCopilotHooks(
  */
 async function installKiroHooks(
   platformBase: string,
-  skillsDir: string,
   hooksConfig: Record<string, HookConfig>,
 ): Promise<{ installed: boolean; reason?: string }> {
   const hooksDir = path.join(platformBase, 'hooks');
@@ -723,7 +724,7 @@ async function installKiroHooks(
       },
       then: {
         type: 'runCommand',
-        command: buildHookCommand(skillsDir, scriptRelPath),
+        command: buildHookCommand(platformBase, scriptRelPath),
       },
     };
 

--- a/test/ts/skills.test.ts
+++ b/test/ts/skills.test.ts
@@ -189,6 +189,8 @@ describe('skills', () => {
   describe('installCometHooksForPlatform', () => {
     const staleCometCommand = 'bash .legacy/skills/comet/scripts/comet-hook-guard.sh';
     const currentCometScript = 'comet/scripts/comet-hook-guard.sh';
+    const expectedHookCommand = (skillsDir: string) =>
+      `bash '${path.join(tmpDir, skillsDir, 'skills', currentCometScript).replace(/\\/g, '/')}'`;
 
     it('merges Claude-style hooks into an existing matcher group without replacing user hooks', async () => {
       const platform: Platform = {
@@ -235,7 +237,7 @@ describe('skills', () => {
         { type: 'command', command: 'echo user-write-check' },
         {
           type: 'command',
-          command: `bash .claude/skills/${currentCometScript}`,
+          command: expectedHookCommand('.claude'),
         },
       ]);
 
@@ -328,7 +330,7 @@ describe('skills', () => {
           },
           {
             type: 'command',
-            command: `bash ${skillsDir}/skills/${currentCometScript}`,
+            command: expectedHookCommand(skillsDir),
             description: 'Block code writes in wrong Comet phase (open/design/archive)',
           },
         ]);
@@ -389,7 +391,7 @@ describe('skills', () => {
         },
         {
           type: 'command',
-          command: `bash .gemini/skills/${currentCometScript}`,
+          command: expectedHookCommand('.gemini'),
           name: 'Block code writes in wrong Comet phase (open/design/archive)',
         },
       ]);
@@ -430,7 +432,7 @@ describe('skills', () => {
       expect(firstInstall.hooks.pre_write_code).toEqual([
         { command: 'echo user-write-check', show_output: false },
         {
-          command: `bash .windsurf/skills/${currentCometScript}`,
+          command: expectedHookCommand('.windsurf'),
           show_output: true,
         },
       ]);
@@ -438,6 +440,41 @@ describe('skills', () => {
       await installCometHooksForPlatform(tmpDir, platform);
       const secondInstall = JSON.parse(await fs.readFile(hooksPath, 'utf-8'));
       expect(secondInstall).toEqual(firstInstall);
+    });
+
+    it('writes Claude hooks with absolute script paths for nested working directories', async () => {
+      const platform: Platform = {
+        id: 'claude',
+        name: 'Claude Code',
+        skillsDir: '.claude',
+        openspecToolId: 'claude',
+        supportsHooks: true,
+        hookFormat: 'claude-code',
+      };
+      const settingsPath = path.join(tmpDir, '.claude', 'settings.local.json');
+      const scriptPath = path.join(
+        tmpDir,
+        '.claude',
+        'skills',
+        'comet',
+        'scripts',
+        'comet-hook-guard.sh',
+      );
+      const submoduleDir = path.join(tmpDir, 'front');
+      await fs.mkdir(path.dirname(scriptPath), { recursive: true });
+      await fs.writeFile(scriptPath, '#!/bin/sh\nexit 0\n', 'utf-8');
+      await fs.mkdir(submoduleDir, { recursive: true });
+
+      await installCometHooksForPlatform(tmpDir, platform);
+
+      const settings = JSON.parse(await fs.readFile(settingsPath, 'utf-8'));
+      const command = settings.hooks.PreToolUse[0].hooks[0].command;
+      expect(command).toBe(expectedHookCommand('.claude'));
+      const commandPath = command.match(/^bash '([^']+)'$/)?.[1];
+      expect(commandPath).toBeDefined();
+      expect(path.isAbsolute(commandPath!)).toBe(true);
+      expect(path.resolve(submoduleDir, commandPath!).replace(/\\/g, '/')).toBe(commandPath);
+      await expect(fs.access(commandPath!)).resolves.toBeUndefined();
     });
   });
 

--- a/test/ts/uninstall.test.ts
+++ b/test/ts/uninstall.test.ts
@@ -243,6 +243,9 @@ describe('uninstall', () => {
   describe('removeCometHooksForPlatform', () => {
     it('removes Claude Code hooks while preserving non-Comet hooks', async () => {
       const claudePlatform: Platform = PLATFORMS.find((p) => p.id === 'claude')!;
+      const absoluteHookCommand = `bash '${path
+        .join(tmpDir, '.claude', 'skills', 'comet', 'scripts', 'comet-hook-guard.sh')
+        .replace(/\\/g, '/')}'`;
 
       const settingsDir = path.join(tmpDir, '.claude');
       await fs.mkdir(settingsDir, { recursive: true });
@@ -257,6 +260,10 @@ describe('uninstall', () => {
                   type: 'command',
                   command: 'bash .claude/skills/comet/scripts/comet-hook-guard.sh',
                 },
+                {
+                  type: 'command',
+                  command: absoluteHookCommand,
+                },
                 { type: 'command', command: 'bash my-custom-hook.sh' },
               ],
             },
@@ -266,9 +273,17 @@ describe('uninstall', () => {
       await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
 
       await installCometHooksForPlatform(tmpDir, claudePlatform, 'project');
+      const installed = JSON.parse(await fs.readFile(settingsPath, 'utf-8'));
+      const installedCommands = installed.hooks.PreToolUse.flatMap((g: Record<string, unknown>) =>
+        (g.hooks as Array<Record<string, unknown>>).map((h: Record<string, unknown>) => h.command),
+      );
+      expect(installedCommands).toContain('bash my-custom-hook.sh');
+      expect(installedCommands.filter((c: string) => c.includes('comet-hook-guard'))).toEqual([
+        absoluteHookCommand,
+      ]);
 
       const result = await removeCometHooksForPlatform(tmpDir, claudePlatform, 'project');
-      expect(result.removed).toBeGreaterThan(0);
+      expect(result.removed).toBe(1);
 
       const updatedContent = await fs.readFile(settingsPath, 'utf-8');
       const updated = JSON.parse(updatedContent);


### PR DESCRIPTION
 What Changed

  - src/core/skills.ts
      - 新增 shellQuote()，用于安全包装 hook 命令路径。
      - buildHookCommand() 改为从 platformBase/skills/... 解析绝对路径。
      - 所有 hook 安装格式统一使用新的绝对路径命令：
          - Claude-style
          - Qwen / Qoder
          - Gemini
          - Windsurf
          - GitHub Copilot
          - Kiro

      - isManagedHookCommand() 更新为能识别无引号、单引号、双引号三种 Bash 命令格式，确保旧相对路径和新绝对路径都能被识别为 Comet 管理的 hook。
      - GitHub Copilot 的 PowerShell wrapper 也改用统一 shell quoting。

  - test/ts/skills.test.ts
      - 更新现有 hook 安装测试，断言生成的是绝对路径命令。
      - 新增嵌套工作目录回归测试，验证 Claude hook 的绝对路径即使从子目录解析也仍然指向正确脚本。

  - test/ts/uninstall.test.ts
      - 增强卸载测试，覆盖旧相对路径 hook、新绝对路径 hook 和用户自定义 hook 同时存在的场景。
      - 验证重新安装会保留用户 hook、替换/去重 Comet hook。
      - 验证卸载只移除 Comet 管理的 hook，不误删用户自定义 hook。

  - CHANGELOG.md
      - 新增 0.3.12 changelog，记录 hook 路径修复和回归测试覆盖。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Comet hook installation so hook commands use quoted absolute paths, helping them work correctly from nested repository folders.
  * Improved detection and replacement of existing managed hook entries, reducing duplicate or stale hook commands during updates.
  * Updated hook removal behavior to keep custom user hooks intact while removing only Comet-managed entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->