### PR TITLE
fix: make comet hook guard fail closed on invalid state

### DIFF
--- a/assets/skills/comet/scripts/comet-hook-guard.sh
+++ b/assets/skills/comet/scripts/comet-hook-guard.sh
@@ -170,8 +170,8 @@ if [ -z "$PHASE" ]; then
 fi
 
 if [ -z "$PHASE" ]; then
-  echo "[COMET-HOOK] allowed: no phase in .comet.yaml" >&2
-  exit 0
+  echo "[COMET-HOOK] blocked: active .comet.yaml has no phase; repair Comet state before writing files" >&2
+  exit 2
 fi
 
 # ── Whitelist: phase-aware allowed paths ─────────────────────────
@@ -282,13 +282,13 @@ case "$PHASE" in
     if [ -n "$GOV_YAML" ]; then
       _wf=$(read_field "workflow" "$GOV_YAML")
       _dd=$(read_field "design_doc" "$GOV_YAML")
-      if [ "$_wf" = "full" ] && { [ -z "$_dd" ] || [ "$_dd" = "null" ]; }; then
+      if [ "$_wf" = "full" ] && { [ -z "$_dd" ] || [ "$_dd" = "null" ] || [ ! -r "$_dd" ] || [ ! -s "$_dd" ]; }; then
         echo "" >&2
         echo "╔══════════════════════════════════════════╗" >&2
         echo "║     COMET PHASE GUARD — WRITE BLOCKED    ║" >&2
         echo "╚══════════════════════════════════════════╝" >&2
         echo "" >&2
-        echo "  Current phase: $PHASE (workflow: full), but design_doc is empty" >&2
+        echo "  Current phase: $PHASE (workflow: full), but design_doc is missing or empty" >&2
         echo "  Target file: $RELPATH" >&2
         echo "" >&2
         echo "  ❌ Illegal phase jump detected: full workflow entered $PHASE without a Design Doc" >&2

--- a/test/ts/comet-scripts.test.ts
+++ b/test/ts/comet-scripts.test.ts
@@ -3775,6 +3775,24 @@ describeShell('comet shell scripts', () => {
       expect(result.status).toBe(0);
     }, 20_000);
 
+    it('blocks source code writes when active comet state has no phase', async () => {
+      await createChange(
+        tmpDir,
+        'missing-phase',
+        ['workflow: full', 'phase:', 'design_doc: null', 'archived: false', ''].join('\n'),
+      );
+
+      const srcDir = path.join(tmpDir, 'src');
+      await fs.mkdir(srcDir, { recursive: true });
+      const targetFile = path.join(srcDir, 'feature.ts');
+
+      const result = runHookGuard(tmpDir, hookGuardScript, hookStdin(targetFile));
+
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('active .comet.yaml has no phase');
+      expect(result.stderr).not.toMatch(/[一-龥]/);
+    }, 20_000);
+
     it('allows writes to openspec/ in design phase', async () => {
       await createChange(
         tmpDir,
@@ -3962,6 +3980,8 @@ describeShell('comet shell scripts', () => {
         ].join('\n'),
       );
 
+      await writeFile(path.join(tmpDir, 'docs/superpowers/specs/test.md'), '# Design Doc\n');
+
       const srcDir = path.join(tmpDir, 'src');
       await fs.mkdir(srcDir, { recursive: true });
       const targetFile = path.join(srcDir, 'feature.ts');
@@ -3999,6 +4019,8 @@ describeShell('comet shell scripts', () => {
           '',
         ].join('\n'),
       );
+
+      await writeFile(path.join(tmpDir, 'docs/superpowers/specs/test.md'), '# Design Doc\n');
 
       const srcDir = path.join(tmpDir, 'src');
       await fs.mkdir(srcDir, { recursive: true });
@@ -4183,7 +4205,34 @@ describeShell('comet shell scripts', () => {
       expect(result.stderr).toContain('BLOCKED');
       expect(result.stderr).toContain('design_doc');
       expect(result.stderr).toContain(
-        'Current phase: build (workflow: full), but design_doc is empty',
+        'Current phase: build (workflow: full), but design_doc is missing or empty',
+      );
+      expect(result.stderr).not.toMatch(/[一-龥]/);
+    }, 20_000);
+
+    it('blocks full-workflow build source writes when design_doc points to a missing file', async () => {
+      await createChange(
+        tmpDir,
+        'full-build-missing-doc',
+        [
+          'workflow: full',
+          'phase: build',
+          'design_doc: docs/superpowers/missing.md',
+          'archived: false',
+          '',
+        ].join('\n'),
+      );
+
+      const srcDir = path.join(tmpDir, 'src');
+      await fs.mkdir(srcDir, { recursive: true });
+      const targetFile = path.join(srcDir, 'feature.ts');
+
+      const result = runHookGuard(tmpDir, hookGuardScript, hookStdin(targetFile));
+
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('design_doc');
+      expect(result.stderr).toContain(
+        'Current phase: build (workflow: full), but design_doc is missing or empty',
       );
       expect(result.stderr).not.toMatch(/[一-龥]/);
     }, 20_000);


### PR DESCRIPTION
## Summary

Make `comet-hook-guard.sh` fail closed when an active Comet state is malformed or points to missing design evidence.

## Why

Two invalid states currently bypass the phase guard:

- an active `.comet.yaml` with an empty or missing `phase` exits successfully
- a full workflow in `build`/`verify` only checks that `design_doc` is non-empty, so paths such as `missing.md` still allow source writes

Both cases can bypass the intended open/design/archive source-write protections. The rest of Comet already treats `design_doc` as evidence that must point to an existing file before leaving design, so the hook guard should enforce the same invariant when protecting source writes.

## Changes

- Block writes when an active `.comet.yaml` has no phase.
- Require full-workflow `design_doc` to be readable and non-empty before allowing `build`/`verify` source writes.
- Add hook guard regression coverage for:
  - missing `phase`
  - missing `design_doc` file
  - existing build/verify allow paths with a real design doc file

## Validation

- `bash -n assets/skills/comet/scripts/comet-hook-guard.sh`
- `git diff --check`
- Manual hook smoke checks:
  - missing `phase` returns exit 2
  - missing `design_doc` file returns exit 2
  - valid `design_doc` file in build phase returns exit 0

I could not run the full Vitest suite in this sandbox because `pnpm@10.18.3` attempted to fetch from `registry.npmjs.org`, and DNS/network access to the registry failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Source-code writes are now blocked when the active Comet state is incomplete.
  * Full workflow checks now also block when a referenced design doc is missing, unreadable, or empty.
  * Error messages were updated to better reflect these validation failures.
* **Tests**
  * Expanded automated coverage for blocked writes and design-doc validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->