### PR TITLE
fix: clarify archive confirmation routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ This is the first beta of the 0.4.0 line. Relative to 0.3.9, Comet becomes a cro
 
 ### Fixed
 
-- **Archive confirmation routing**: Clarifies that `phase: archive` with `archived` not `true` remains a final confirmation point, so agents no longer treat a verify-guard phase mismatch as workflow completion before the user chooses archive, re-verification, or waiting.
+- **Archive confirmation guard**: Classic archive now requires an explicit `archive_confirmation: confirmed` state before the mutating archive command can finalize a change, preventing skipped final confirmation from moving a change into archive and marking it archived.
 - **Windows path handling**: Fixes OpenSpec init/update path quoting for directories with spaces on Windows, so `comet init` no longer fails when the project path contains spaces.
 - **Git submodule script lookup**: Comet hook and runtime script resolution now uses the containing project root when an agent works inside a Git submodule, so submodule edits no longer fail because `.claude/skills/comet/scripts/*` is only present at the parent project level ([#136](https://github.com/rpamis/comet/issues/136)).
 - **Superpowers workspace writes**: Comet phase write guards now allow Superpowers to write its `.superpowers/` workspace during protected workflow phases, so Superpowers progress files are no longer mistaken for blocked source edits ([#154](https://github.com/rpamis/comet/issues/154)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This is the first beta of the 0.4.0 line. Relative to 0.3.9, Comet becomes a cro
 
 ### Fixed
 
+- **Archive confirmation routing**: Clarifies that `phase: archive` with `archived` not `true` remains a final confirmation point, so agents no longer treat a verify-guard phase mismatch as workflow completion before the user chooses archive, re-verification, or waiting.
 - **Windows path handling**: Fixes OpenSpec init/update path quoting for directories with spaces on Windows, so `comet init` no longer fails when the project path contains spaces.
 - **Git submodule script lookup**: Comet hook and runtime script resolution now uses the containing project root when an agent works inside a Git submodule, so submodule edits no longer fail because `.claude/skills/comet/scripts/*` is only present at the parent project level ([#136](https://github.com/rpamis/comet/issues/136)).
 - **Superpowers workspace writes**: Comet phase write guards now allow Superpowers to write its `.superpowers/` workspace during protected workflow phases, so Superpowers progress files are no longer mistaken for blocked source edits ([#154](https://github.com/rpamis/comet/issues/154)).

--- a/assets/skills-zh/comet-archive/SKILL.md
+++ b/assets/skills-zh/comet-archive/SKILL.md
@@ -38,22 +38,23 @@ node "$COMET_STATE" check <name> archive
 - 本次归档将执行的不可逆动作：按 OpenSpec delta 语义合并主 spec、标注 design doc / plan、移动 change 到 archive 目录
 
 用户确认问题必须以单选题形式呈现，包含以下选项：
-- 「确认归档」— 立即执行归档脚本，完成 spec 合并和 change 移动
+- 「确认归档」— 先运行 `node "$COMET_STATE" transition <change-name> archive-confirm` 写入最终确认状态，再执行归档脚本，完成 spec 合并和 change 移动
 - 「需要调整或重新验证」— 不执行归档；运行 `node "$COMET_STATE" transition <change-name> archive-reopen` 回到 `phase: verify`，再调用 `/comet-verify`。若验证阶段确认需要修复，再按 `/comet-verify` 的验证失败决策回到 `/comet-build`
 - 「暂不归档」— 不执行归档，保留当前 `phase: archive` 状态，等待用户稍后再次调用 `/comet-archive`
 
-只有用户选择「确认归档」后，才允许继续 Step 2。用户选择「需要调整或重新验证」后，必须先执行 `archive-reopen` 状态回退，不得手动编辑 `.comet.yaml`。
+只有用户选择「确认归档」并且 `archive-confirm` transition 成功后，才允许继续 Step 2。用户选择「需要调整或重新验证」后，必须先执行 `archive-reopen` 状态回退，不得手动编辑 `.comet.yaml`。
 
 ### 2. 执行归档
 
-运行归档脚本，自动完成以下全部步骤：
+先写入最终确认状态，再运行归档脚本：
 
 ```bash
+node "$COMET_STATE" transition <change-name> archive-confirm
 node "$COMET_ARCHIVE" "<change-name>"
 ```
 
 脚本自动执行：
-1. 入口状态验证（phase=archive, verify_result=pass, archived=false）
+1. 入口状态验证（phase=archive, verify_result=pass, archive_confirmation=confirmed, archived=false）
 2. Design doc 前置元数据标注（archived-with, status）
 3. Plan 前置元数据标注（archived-with）
 4. 调用 OpenSpec archive 按 delta 语义合并主 spec 并移动 change 到归档目录

--- a/assets/skills-zh/comet/SKILL.md
+++ b/assets/skills-zh/comet/SKILL.md
@@ -112,6 +112,9 @@ agent 做决策只需读本节，参考附录按需查阅。
 - 若 `phase: verify` 且 `verify_result: fail`，进入验证失败决策阻塞点：暂停并询问用户修复或接受偏差；用户选择修复后才运行 `node "$COMET_STATE" transition <name> verify-fail` 并调用 `/comet-build`
 - 若 `phase: open` 但 proposal/design/tasks 已完整，先运行 `node "$COMET_GUARD" <change-name> open --apply` 修正状态，再继续判定
 - 若 `phase: archive`，只允许调用 `/comet-archive`；`/comet-archive` 必须先等待归档前最终确认，归档成功后 change 会移动到 archive 目录，不再对原活跃目录运行 guard
+  - `phase: archive` 且 `archived` 不是 `true` 不是终局；必须进入 `/comet-archive` 的最终确认分支，让用户选择确认归档、需要调整或重新验证、暂不归档
+  - 不要通过复跑 verify guard 来判断 archive 是否还能继续；archive 阶段复跑 `verify --apply` 只表示 phase 不匹配，不能解释为流程已完成
+  - 只有 `archived: true` 或 change 已移入 archive 才是终局
 
 **Step 2: 阶段判定**（按顺序，命中即停）
 

--- a/assets/skills-zh/comet/SKILL.md
+++ b/assets/skills-zh/comet/SKILL.md
@@ -112,9 +112,6 @@ agent 做决策只需读本节，参考附录按需查阅。
 - 若 `phase: verify` 且 `verify_result: fail`，进入验证失败决策阻塞点：暂停并询问用户修复或接受偏差；用户选择修复后才运行 `node "$COMET_STATE" transition <name> verify-fail` 并调用 `/comet-build`
 - 若 `phase: open` 但 proposal/design/tasks 已完整，先运行 `node "$COMET_GUARD" <change-name> open --apply` 修正状态，再继续判定
 - 若 `phase: archive`，只允许调用 `/comet-archive`；`/comet-archive` 必须先等待归档前最终确认，归档成功后 change 会移动到 archive 目录，不再对原活跃目录运行 guard
-  - `phase: archive` 且 `archived` 不是 `true` 不是终局；必须进入 `/comet-archive` 的最终确认分支，让用户选择确认归档、需要调整或重新验证、暂不归档
-  - 不要通过复跑 verify guard 来判断 archive 是否还能继续；archive 阶段复跑 `verify --apply` 只表示 phase 不匹配，不能解释为流程已完成
-  - 只有 `archived: true` 或 change 已移入 archive 才是终局
 
 **Step 2: 阶段判定**（按顺序，命中即停）
 

--- a/assets/skills-zh/comet/reference/comet-yaml-fields.md
+++ b/assets/skills-zh/comet/reference/comet-yaml-fields.md
@@ -26,6 +26,7 @@ verification_report: null
 branch_status: pending
 created_at: 2026-05-26
 verified_at: null
+archive_confirmation: null
 archived: false
 ```
 
@@ -52,6 +53,7 @@ archived: false
 | `branch_status` | `pending` 或 `handled`，分支处理完成后设为 `handled` |
 | `created_at` | change 创建日期（init 时自动写入），格式 `YYYY-MM-DD` |
 | `verified_at` | 验证通过时间，可为空 |
+| `archive_confirmation` | `null`、`pending` 或 `confirmed`。`verify-pass` 进入 archive 阶段时写入 `pending`；用户在 `/comet-archive` 最终确认选择「确认归档」后，`archive-confirm` transition 写入 `confirmed`；`archive-reopen` 会清空该字段，防止复用旧确认 |
 | `archived` | change 是否已归档 |
 
 ## 可选字段
@@ -72,4 +74,5 @@ archived: false
 - `build_mode: direct` 默认只允许 `hotfix` / `tweak`；full workflow 需要 `direct_override: true`
 - `build_pause` 不是执行方式，不得写入 `build_mode`
 - 这些约束同时存在于 `comet-guard.mjs build --apply` 和 `comet-state.mjs transition <name> build-complete`
+- `archived` transition 和真实归档命令都要求 `archive_confirmation: confirmed`；未最终确认的 archive 状态只能继续等待确认、`archive-reopen` 回到 verify，或暂不归档
 - `preset-escalate` 事件：仅允许 `hotfix`/`tweak` workflow 在 `phase: build` 时调用，原子地把 `workflow`/`classic_profile` 置为 `full`、`phase` 回退到 `design`、清空 `design_doc`（满足 comet-design 入口要求）。这是预设升级到 full 的唯一合法通道——直接 `set phase design` 会被状态机硬拦截，`set classic_profile` 属于 machine-owned 字段不可手动设置

--- a/assets/skills/comet-archive/SKILL.md
+++ b/assets/skills/comet-archive/SKILL.md
@@ -38,22 +38,23 @@ Before confirmation, show the user a brief summary:
 - Irreversible actions this archive will perform: merge main specs with OpenSpec delta semantics, annotate design doc / plan, and move the change to the archive directory
 
 The user confirmation question must be presented as a single-select question with these options:
-- "Confirm archive" — immediately run the archive script to complete spec merge and change movement
+- "Confirm archive" — first run `node "$COMET_STATE" transition <change-name> archive-confirm` to write the final confirmation state, then run the archive script to complete spec merge and change movement
 - "Needs adjustment or re-verification" — do not archive; run `node "$COMET_STATE" transition <change-name> archive-reopen` to return to `phase: verify`, then invoke `/comet-verify`. If verification confirms fixes are needed, follow `/comet-verify`'s verification-failure decision flow back to `/comet-build`
 - "Do not archive yet" — do not archive; keep the current `phase: archive` state and wait for the user to invoke `/comet-archive` again later
 
-Only after the user selects "Confirm archive" may Step 2 continue. After the user selects "Needs adjustment or re-verification", must first run the `archive-reopen` state transition; do not edit `.comet.yaml` manually.
+Only after the user selects "Confirm archive" and the `archive-confirm` transition succeeds may Step 2 continue. After the user selects "Needs adjustment or re-verification", must first run the `archive-reopen` state transition; do not edit `.comet.yaml` manually.
 
 ### 2. Execute Archive
 
-Run the archive script to automatically complete all steps:
+Write the final confirmation state, then run the archive script:
 
 ```bash
+node "$COMET_STATE" transition <change-name> archive-confirm
 node "$COMET_ARCHIVE" "<change-name>"
 ```
 
 The script automatically executes:
-1. Entry state validation (phase=archive, verify_result=pass, archived=false)
+1. Entry state validation (phase=archive, verify_result=pass, archive_confirmation=confirmed, archived=false)
 2. Design doc frontmatter annotation (archived-with, status)
 3. Plan frontmatter annotation (archived-with)
 4. OpenSpec archive for delta-merge semantics and moving the change to the archive directory

--- a/assets/skills/comet/SKILL.md
+++ b/assets/skills/comet/SKILL.md
@@ -112,9 +112,6 @@ Prefer reading `openspec/changes/<name>/.comet.yaml`. If not available, fall bac
 - If `phase: verify` and `verify_result: fail`, enter the verification failure decision blocking point: pause and ask the user to fix or accept deviation; only after the user chooses fix, run `node "$COMET_STATE" transition <name> verify-fail` and invoke `/comet-build`
 - If `phase: open` but proposal/design/tasks are complete, first run `node "$COMET_GUARD" <change-name> open --apply` to repair state, then continue detection
 - If `phase: archive`, only invoke `/comet-archive`; `/comet-archive` must first wait for final archive confirmation. After archive succeeds, the change moves to the archive directory, so do not run guard against the old active directory
-  - `phase: archive` with `archived` not `true` is not terminal; enter `/comet-archive` final confirmation and let the user choose confirm archive, needs adjustment or re-verification, or do not archive yet
-  - Do not rerun the verify guard to test whether archive can continue; rerunning `verify --apply` in archive only means the phase does not match, and must not be interpreted as workflow complete
-  - Only `archived: true` or a change already moved into archive is terminal
 
 **Step 2: Phase Determination** (check in order, first match wins)
 

--- a/assets/skills/comet/SKILL.md
+++ b/assets/skills/comet/SKILL.md
@@ -112,6 +112,9 @@ Prefer reading `openspec/changes/<name>/.comet.yaml`. If not available, fall bac
 - If `phase: verify` and `verify_result: fail`, enter the verification failure decision blocking point: pause and ask the user to fix or accept deviation; only after the user chooses fix, run `node "$COMET_STATE" transition <name> verify-fail` and invoke `/comet-build`
 - If `phase: open` but proposal/design/tasks are complete, first run `node "$COMET_GUARD" <change-name> open --apply` to repair state, then continue detection
 - If `phase: archive`, only invoke `/comet-archive`; `/comet-archive` must first wait for final archive confirmation. After archive succeeds, the change moves to the archive directory, so do not run guard against the old active directory
+  - `phase: archive` with `archived` not `true` is not terminal; enter `/comet-archive` final confirmation and let the user choose confirm archive, needs adjustment or re-verification, or do not archive yet
+  - Do not rerun the verify guard to test whether archive can continue; rerunning `verify --apply` in archive only means the phase does not match, and must not be interpreted as workflow complete
+  - Only `archived: true` or a change already moved into archive is terminal
 
 **Step 2: Phase Determination** (check in order, first match wins)
 

--- a/assets/skills/comet/reference/comet-yaml-fields.md
+++ b/assets/skills/comet/reference/comet-yaml-fields.md
@@ -26,6 +26,7 @@ verification_report: null
 branch_status: pending
 created_at: 2026-05-26
 verified_at: null
+archive_confirmation: null
 archived: false
 ```
 
@@ -52,6 +53,7 @@ archived: false
 | `branch_status` | `pending` or `handled`; set to `handled` after branch handling completes |
 | `created_at` | Change creation date (auto-written at init), format `YYYY-MM-DD` |
 | `verified_at` | Verification pass timestamp; may be empty |
+| `archive_confirmation` | `null`, `pending`, or `confirmed`. `verify-pass` writes `pending` when entering the archive phase; after the user chooses "Confirm archive" in `/comet-archive`, the `archive-confirm` transition writes `confirmed`; `archive-reopen` clears this field so stale confirmation cannot be reused |
 | `archived` | Whether the change has been archived |
 
 ## Optional Fields
@@ -72,4 +74,5 @@ archived: false
 - `build_mode: direct` defaults to `hotfix`/`tweak` only; full workflow requires `direct_override: true`
 - `build_pause` is not an execution mode; must not be written to `build_mode`
 - These constraints exist in both `comet-guard.mjs build --apply` and `comet-state.mjs transition <name> build-complete`
+- The `archived` transition and mutating archive command both require `archive_confirmation: confirmed`; unconfirmed archive state may only wait for confirmation, `archive-reopen` back to verify, or remain unarchived
 - `preset-escalate` event: only allows `hotfix`/`tweak` workflow at `phase: build`; atomically sets `workflow`/`classic_profile` to `full`, rewinds `phase` to `design`, and clears `design_doc` (satisfying the comet-design entry requirement). This is the only legal channel for a preset → full upgrade — direct `set phase design` is hard-blocked by the state machine, and `set classic_profile` is a machine-owned field that cannot be set manually

--- a/assets/skills/comet/scripts/comet-runtime.mjs
+++ b/assets/skills/comet/scripts/comet-runtime.mjs
@@ -7707,6 +7707,10 @@ async function collectClassicEvidence(changeDir, projection) {
     handoff.satisfied = false;
     handoff.detail = "handoff hash is missing";
   }
+  evidence.push({
+    code: "archive.confirmed",
+    satisfied: classic?.archiveConfirmation === "confirmed"
+  });
   return evidence;
 }
 
@@ -7757,7 +7761,7 @@ function resolveArchive(profile, classic, evidence) {
   if (classic.verifyResult !== "pass") {
     throw new Error("archive requires verify_result=pass");
   }
-  return evidenceSatisfied(evidence, "archive.confirmed") ? `${profile}.archive.execute` : `${profile}.archive.confirm`;
+  return classic.archiveConfirmation === "confirmed" || evidenceSatisfied(evidence, "archive.confirmed") ? `${profile}.archive.execute` : `${profile}.archive.confirm`;
 }
 function resolveClassicStepId(classic, evidence) {
   const profile = profileFor(classic);
@@ -7804,6 +7808,7 @@ var ISOLATIONS = ["branch", "worktree"];
 var VERIFY_MODES = ["light", "full"];
 var VERIFY_RESULTS = ["pending", "pass", "fail"];
 var BRANCH_STATUSES = ["pending", "handled"];
+var ARCHIVE_CONFIRMATIONS = ["pending", "confirmed"];
 var CLASSIC_WIRE_KEYS = [
   "workflow",
   "language",
@@ -7825,6 +7830,7 @@ var CLASSIC_WIRE_KEYS = [
   "branch_status",
   "created_at",
   "verified_at",
+  "archive_confirmation",
   "archived",
   "direct_override",
   "build_command",
@@ -7935,6 +7941,7 @@ function classicStateFromDocument(doc) {
     branchStatus: enumValue(doc, "branch_status", BRANCH_STATUSES),
     createdAt: nullableString(doc, "created_at"),
     verifiedAt: nullableString(doc, "verified_at"),
+    archiveConfirmation: enumValue(doc, "archive_confirmation", ARCHIVE_CONFIRMATIONS),
     archived: booleanValue(doc, "archived", false),
     directOverride: booleanValue(doc, "direct_override"),
     buildCommand: nullableString(doc, "build_command"),
@@ -8000,6 +8007,7 @@ function classicStateToDocument(state) {
     branch_status: state.branchStatus,
     created_at: state.createdAt,
     verified_at: state.verifiedAt,
+    archive_confirmation: state.archiveConfirmation,
     archived: state.archived,
     direct_override: state.directOverride,
     build_command: state.buildCommand,
@@ -9081,6 +9089,7 @@ var CLASSIC_TRANSITION_EVENTS = [
   "build-complete",
   "verify-pass",
   "verify-fail",
+  "archive-confirm",
   "archive-reopen",
   "archived",
   "preset-escalate"
@@ -9111,6 +9120,11 @@ var CLASSIC_TRANSITION_TABLE = {
     from: "verify",
     guardRefs: ["verification-failed"]
   },
+  "archive-confirm": {
+    event: "archive-confirm",
+    from: "archive",
+    guardRefs: ["archive-final-confirmation"]
+  },
   "archive-reopen": {
     event: "archive-reopen",
     from: "archive",
@@ -9119,7 +9133,7 @@ var CLASSIC_TRANSITION_TABLE = {
   archived: {
     event: "archived",
     from: "archive",
-    guardRefs: ["verify-result-pass"]
+    guardRefs: ["verify-result-pass", "archive-confirmed"]
   },
   "preset-escalate": {
     event: "preset-escalate",
@@ -9167,6 +9181,7 @@ function applyClassicTransition(current, event, options = {}) {
     setField(classic, effects, "verifyResult", "pass");
     setField(classic, effects, "phase", "archive");
     setField(classic, effects, "verifiedAt", dateOnly(now));
+    setField(classic, effects, "archiveConfirmation", "pending");
   } else if (event === "verify-fail") {
     setField(classic, effects, "verifyResult", "fail");
     setField(classic, effects, "phase", "build");
@@ -9180,14 +9195,24 @@ function applyClassicTransition(current, event, options = {}) {
     setField(classic, effects, "classicProfile", "full");
     setField(classic, effects, "phase", "design");
     setField(classic, effects, "designDoc", null);
+  } else if (event === "archive-confirm") {
+    if (classic.verifyResult !== "pass") {
+      throw new Error(`Cannot apply ${event}: verifyResult must be pass`);
+    }
+    if (classic.archived) throw new Error(`Cannot apply ${event}: already archived`);
+    setField(classic, effects, "archiveConfirmation", "confirmed");
   } else if (event === "archive-reopen") {
     if (classic.archived) throw new Error(`Cannot apply ${event}: already archived`);
     setField(classic, effects, "verifyResult", "pending");
     setField(classic, effects, "phase", "verify");
     setField(classic, effects, "verifiedAt", null);
+    setField(classic, effects, "archiveConfirmation", null);
   } else {
     if (classic.verifyResult !== "pass") {
       throw new Error(`Cannot apply ${event}: verifyResult must be pass`);
+    }
+    if (classic.archiveConfirmation !== "confirmed") {
+      throw new Error(`Cannot apply ${event}: archiveConfirmation must be confirmed`);
     }
     setField(classic, effects, "archived", true);
   }
@@ -9404,6 +9429,13 @@ var classicArchiveCommand = async (args) => {
       if (runtime.run.pending && runtime.run.pending !== actionId) {
         throw new ArchiveFailure(red(`FATAL: another action is pending: ${runtime.run.pending}`));
       }
+      if (!recovering && !classic.archived && classic.archiveConfirmation !== "confirmed") {
+        throw new ArchiveFailure(
+          red(
+            `FATAL: archive_confirmation is '${classic.archiveConfirmation ?? "null"}', expected 'confirmed'. Run final archive confirmation first.`
+          )
+        );
+      }
       if (!recovering) {
         const action = {
           id: actionId,
@@ -9475,7 +9507,10 @@ var classicArchiveCommand = async (args) => {
         archive_directory: archiveDir
       };
       await writeArtifacts(archiveDir, archivedProjection.run.artifactsRef, artifacts);
-      const archiveTransition = applyClassicTransition(archivedProjection.classic, "archived");
+      const archiveTransition = applyClassicTransition(
+        recovering && archivedProjection.classic.archiveConfirmation !== "confirmed" ? { ...archivedProjection.classic, archiveConfirmation: "confirmed" } : archivedProjection.classic,
+        "archived"
+      );
       const archivedClassic = archiveTransition.classic;
       let transitionedRun = archivedProjection.run;
       if (archivedProjection.run.currentStep !== "completed" || archivedProjection.run.status !== "completed") {
@@ -9704,6 +9739,7 @@ var ENUMS = {
   auto_transition: ["true", "false"],
   verify_result: ["pending", "pass", "fail"],
   branch_status: ["pending", "handled"],
+  archive_confirmation: ["pending", "confirmed"],
   archived: ["true", "false"],
   direct_override: ["true", "false"],
   classic_profile: ["full", "hotfix", "tweak"],
@@ -11831,6 +11867,7 @@ var FIELD_ENUMS = {
   auto_transition: ["true", "false"],
   verify_result: ["pending", "pass", "fail"],
   branch_status: ["pending", "handled"],
+  archive_confirmation: ["pending", "confirmed"],
   archived: ["true", "false"],
   direct_override: ["true", "false"],
   classic_profile: PROFILES,
@@ -11846,6 +11883,7 @@ var CLASSIC_FIELD_WIRE_NAMES2 = {
   phase: "phase",
   verificationReport: "verification_report",
   verifiedAt: "verified_at",
+  archiveConfirmation: "archive_confirmation",
   verifyResult: "verify_result",
   workflow: "workflow"
 };
@@ -12024,6 +12062,12 @@ function sparseClassicState(record) {
     branchStatus: enumRecordValue(record, "branch_status", ["pending", "handled"], null),
     createdAt: nullableRecordString(record, "created_at"),
     verifiedAt: nullableRecordString(record, "verified_at"),
+    archiveConfirmation: enumRecordValue(
+      record,
+      "archive_confirmation",
+      ["pending", "confirmed"],
+      null
+    ),
     archived: nullableRecordBoolean(record, "archived") ?? false,
     directOverride: nullableRecordBoolean(record, "direct_override"),
     buildCommand: nullableRecordString(record, "build_command"),
@@ -12207,6 +12251,7 @@ async function init(output, name, workflow) {
     branch_status: "pending",
     created_at: (/* @__PURE__ */ new Date()).toISOString().slice(0, 10),
     verified_at: null,
+    archive_confirmation: null,
     archived: false
   });
   await atomicWrite2(file, document.toString());
@@ -12354,6 +12399,14 @@ async function transition(output, name, event) {
     }
   } else if (event === "verify-fail") {
     await requirePhase(name, "verify");
+  } else if (event === "archive-confirm") {
+    await requirePhase(name, "archive");
+    if (await readField3(name, "verify_result") !== "pass") {
+      fail2(`ERROR: Cannot transition '${name}': verify_result must be pass before archiving`);
+    }
+    if (await readField3(name, "archived") === "true") {
+      fail2(`ERROR: Cannot transition '${name}': already archived`);
+    }
   } else if (event === "preset-escalate") {
     await requirePhase(name, "build");
     const workflow = await readField3(name, "workflow");
@@ -12371,6 +12424,11 @@ async function transition(output, name, event) {
     await requirePhase(name, "archive");
     if (await readField3(name, "verify_result") !== "pass") {
       fail2(`ERROR: Cannot transition '${name}': verify_result must be pass before archiving`);
+    }
+    if (await readField3(name, "archive_confirmation") !== "confirmed") {
+      fail2(
+        `ERROR: Cannot transition '${name}': archive_confirmation must be confirmed before archiving`
+      );
     }
   }
   await applyTransitionEvent(output, name, event);
@@ -12647,12 +12705,14 @@ async function recoverVerify(output, name) {
   );
 }
 async function recoverArchive(output, name) {
+  const archiveConfirmation = await readField3(name, "archive_confirmation");
   output.stdout.push(
     "  Archive:",
     fieldStatus("verify_result", await readField3(name, "verify_result")),
+    fieldStatus("archive_confirmation", archiveConfirmation),
     fieldStatus("archived", await readField3(name, "archived")),
     "",
-    "Recovery action: Run /comet-archive to complete archiving."
+    archiveConfirmation === "confirmed" ? "Recovery action: Archive is confirmed. Run /comet-archive to complete archiving." : "Recovery action: Ask for final archive confirmation in /comet-archive before running the archive command."
   );
 }
 async function recover(output, name) {

--- a/domains/comet-classic/classic-archive.ts
+++ b/domains/comet-classic/classic-archive.ts
@@ -272,6 +272,13 @@ export const classicArchiveCommand: ClassicCommandHandler = async (args) => {
       if (runtime.run.pending && runtime.run.pending !== actionId) {
         throw new ArchiveFailure(red(`FATAL: another action is pending: ${runtime.run.pending}`));
       }
+      if (!recovering && !classic.archived && classic.archiveConfirmation !== 'confirmed') {
+        throw new ArchiveFailure(
+          red(
+            `FATAL: archive_confirmation is '${classic.archiveConfirmation ?? 'null'}', expected 'confirmed'. Run final archive confirmation first.`,
+          ),
+        );
+      }
 
       if (!recovering) {
         const action: EngineAction = {
@@ -350,7 +357,12 @@ export const classicArchiveCommand: ClassicCommandHandler = async (args) => {
       };
       await writeArtifacts(archiveDir, archivedProjection.run.artifactsRef, artifacts);
 
-      const archiveTransition = applyClassicTransition(archivedProjection.classic, 'archived');
+      const archiveTransition = applyClassicTransition(
+        recovering && archivedProjection.classic.archiveConfirmation !== 'confirmed'
+          ? { ...archivedProjection.classic, archiveConfirmation: 'confirmed' }
+          : archivedProjection.classic,
+        'archived',
+      );
       const archivedClassic = archiveTransition.classic;
       let transitionedRun = archivedProjection.run;
       if (

--- a/domains/comet-classic/classic-evidence.ts
+++ b/domains/comet-classic/classic-evidence.ts
@@ -136,5 +136,10 @@ export async function collectClassicEvidence(
     handoff.detail = 'handoff hash is missing';
   }
 
+  evidence.push({
+    code: 'archive.confirmed',
+    satisfied: classic?.archiveConfirmation === 'confirmed',
+  });
+
   return evidence;
 }

--- a/domains/comet-classic/classic-resolver.ts
+++ b/domains/comet-classic/classic-resolver.ts
@@ -73,7 +73,8 @@ function resolveArchive(
   if (classic.verifyResult !== 'pass') {
     throw new Error('archive requires verify_result=pass');
   }
-  return evidenceSatisfied(evidence, 'archive.confirmed')
+  return classic.archiveConfirmation === 'confirmed' ||
+    evidenceSatisfied(evidence, 'archive.confirmed')
     ? `${profile}.archive.execute`
     : `${profile}.archive.confirm`;
 }

--- a/domains/comet-classic/classic-state-command.ts
+++ b/domains/comet-classic/classic-state-command.ts
@@ -55,6 +55,7 @@ const FIELD_ENUMS: Record<string, readonly string[]> = {
   auto_transition: ['true', 'false'],
   verify_result: ['pending', 'pass', 'fail'],
   branch_status: ['pending', 'handled'],
+  archive_confirmation: ['pending', 'confirmed'],
   archived: ['true', 'false'],
   direct_override: ['true', 'false'],
   classic_profile: PROFILES,
@@ -71,6 +72,7 @@ const CLASSIC_FIELD_WIRE_NAMES: Partial<Record<keyof ClassicState, string>> = {
   phase: 'phase',
   verificationReport: 'verification_report',
   verifiedAt: 'verified_at',
+  archiveConfirmation: 'archive_confirmation',
   verifyResult: 'verify_result',
   workflow: 'workflow',
 };
@@ -278,6 +280,12 @@ function sparseClassicState(record: Record<string, unknown>): ClassicState {
     branchStatus: enumRecordValue(record, 'branch_status', ['pending', 'handled'] as const, null),
     createdAt: nullableRecordString(record, 'created_at'),
     verifiedAt: nullableRecordString(record, 'verified_at'),
+    archiveConfirmation: enumRecordValue(
+      record,
+      'archive_confirmation',
+      ['pending', 'confirmed'] as const,
+      null,
+    ),
     archived: nullableRecordBoolean(record, 'archived') ?? false,
     directOverride: nullableRecordBoolean(record, 'direct_override'),
     buildCommand: nullableRecordString(record, 'build_command'),
@@ -492,6 +500,7 @@ async function init(output: CommandOutput, name: string, workflow: string): Prom
     branch_status: 'pending',
     created_at: new Date().toISOString().slice(0, 10),
     verified_at: null,
+    archive_confirmation: null,
     archived: false,
   });
   await atomicWrite(file, document.toString());
@@ -659,6 +668,14 @@ async function transition(output: CommandOutput, name: string, event: string): P
     }
   } else if (event === 'verify-fail') {
     await requirePhase(name, 'verify');
+  } else if (event === 'archive-confirm') {
+    await requirePhase(name, 'archive');
+    if ((await readField(name, 'verify_result')) !== 'pass') {
+      fail(`ERROR: Cannot transition '${name}': verify_result must be pass before archiving`);
+    }
+    if ((await readField(name, 'archived')) === 'true') {
+      fail(`ERROR: Cannot transition '${name}': already archived`);
+    }
   } else if (event === 'preset-escalate') {
     // preset (hotfix/tweak) → full: rewind phase to design so the agent can
     // supplement a Design Doc before continuing. Unlike verify-fail /
@@ -682,6 +699,11 @@ async function transition(output: CommandOutput, name: string, event: string): P
     await requirePhase(name, 'archive');
     if ((await readField(name, 'verify_result')) !== 'pass') {
       fail(`ERROR: Cannot transition '${name}': verify_result must be pass before archiving`);
+    }
+    if ((await readField(name, 'archive_confirmation')) !== 'confirmed') {
+      fail(
+        `ERROR: Cannot transition '${name}': archive_confirmation must be confirmed before archiving`,
+      );
     }
   }
   await applyTransitionEvent(output, name, event as ClassicTransitionEvent);
@@ -1035,12 +1057,16 @@ async function recoverVerify(output: CommandOutput, name: string): Promise<void>
 }
 
 async function recoverArchive(output: CommandOutput, name: string): Promise<void> {
+  const archiveConfirmation = await readField(name, 'archive_confirmation');
   output.stdout.push(
     '  Archive:',
     fieldStatus('verify_result', await readField(name, 'verify_result')),
+    fieldStatus('archive_confirmation', archiveConfirmation),
     fieldStatus('archived', await readField(name, 'archived')),
     '',
-    'Recovery action: Run /comet-archive to complete archiving.',
+    archiveConfirmation === 'confirmed'
+      ? 'Recovery action: Archive is confirmed. Run /comet-archive to complete archiving.'
+      : 'Recovery action: Ask for final archive confirmation in /comet-archive before running the archive command.',
   );
 }
 

--- a/domains/comet-classic/classic-state.ts
+++ b/domains/comet-classic/classic-state.ts
@@ -16,6 +16,7 @@ const ISOLATIONS = ['branch', 'worktree'] as const;
 const VERIFY_MODES = ['light', 'full'] as const;
 const VERIFY_RESULTS = ['pending', 'pass', 'fail'] as const;
 const BRANCH_STATUSES = ['pending', 'handled'] as const;
+const ARCHIVE_CONFIRMATIONS = ['pending', 'confirmed'] as const;
 
 export type ClassicProfile = (typeof CLASSIC_PROFILES)[number];
 export type ClassicPhase = (typeof PHASES)[number];
@@ -42,6 +43,7 @@ export interface ClassicState {
   branchStatus: (typeof BRANCH_STATUSES)[number] | null;
   createdAt: string | null;
   verifiedAt: string | null;
+  archiveConfirmation: (typeof ARCHIVE_CONFIRMATIONS)[number] | null;
   archived: boolean;
   directOverride: boolean | null;
   buildCommand: string | null;
@@ -79,6 +81,7 @@ export const CLASSIC_WIRE_KEYS = [
   'branch_status',
   'created_at',
   'verified_at',
+  'archive_confirmation',
   'archived',
   'direct_override',
   'build_command',
@@ -211,6 +214,7 @@ function classicStateFromDocument(doc: StateDocument): ClassicState | null {
     branchStatus: enumValue(doc, 'branch_status', BRANCH_STATUSES),
     createdAt: nullableString(doc, 'created_at'),
     verifiedAt: nullableString(doc, 'verified_at'),
+    archiveConfirmation: enumValue(doc, 'archive_confirmation', ARCHIVE_CONFIRMATIONS),
     archived: booleanValue(doc, 'archived', false)!,
     directOverride: booleanValue(doc, 'direct_override'),
     buildCommand: nullableString(doc, 'build_command'),
@@ -300,6 +304,7 @@ export function classicStateToDocument(state: ClassicState): StateDocument {
     branch_status: state.branchStatus,
     created_at: state.createdAt,
     verified_at: state.verifiedAt,
+    archive_confirmation: state.archiveConfirmation,
     archived: state.archived,
     direct_override: state.directOverride,
     build_command: state.buildCommand,

--- a/domains/comet-classic/classic-transitions.ts
+++ b/domains/comet-classic/classic-transitions.ts
@@ -6,6 +6,7 @@ export const CLASSIC_TRANSITION_EVENTS = [
   'build-complete',
   'verify-pass',
   'verify-fail',
+  'archive-confirm',
   'archive-reopen',
   'archived',
   'preset-escalate',
@@ -58,6 +59,11 @@ export const CLASSIC_TRANSITION_TABLE: Record<ClassicTransitionEvent, ClassicTra
       from: 'verify',
       guardRefs: ['verification-failed'],
     },
+    'archive-confirm': {
+      event: 'archive-confirm',
+      from: 'archive',
+      guardRefs: ['archive-final-confirmation'],
+    },
     'archive-reopen': {
       event: 'archive-reopen',
       from: 'archive',
@@ -66,7 +72,7 @@ export const CLASSIC_TRANSITION_TABLE: Record<ClassicTransitionEvent, ClassicTra
     archived: {
       event: 'archived',
       from: 'archive',
-      guardRefs: ['verify-result-pass'],
+      guardRefs: ['verify-result-pass', 'archive-confirmed'],
     },
     'preset-escalate': {
       event: 'preset-escalate',
@@ -130,6 +136,7 @@ export function applyClassicTransition(
     setField(classic, effects, 'verifyResult', 'pass');
     setField(classic, effects, 'phase', 'archive');
     setField(classic, effects, 'verifiedAt', dateOnly(now));
+    setField(classic, effects, 'archiveConfirmation', 'pending');
   } else if (event === 'verify-fail') {
     setField(classic, effects, 'verifyResult', 'fail');
     setField(classic, effects, 'phase', 'build');
@@ -143,14 +150,24 @@ export function applyClassicTransition(
     setField(classic, effects, 'classicProfile', 'full');
     setField(classic, effects, 'phase', 'design');
     setField(classic, effects, 'designDoc', null);
+  } else if (event === 'archive-confirm') {
+    if (classic.verifyResult !== 'pass') {
+      throw new Error(`Cannot apply ${event}: verifyResult must be pass`);
+    }
+    if (classic.archived) throw new Error(`Cannot apply ${event}: already archived`);
+    setField(classic, effects, 'archiveConfirmation', 'confirmed');
   } else if (event === 'archive-reopen') {
     if (classic.archived) throw new Error(`Cannot apply ${event}: already archived`);
     setField(classic, effects, 'verifyResult', 'pending');
     setField(classic, effects, 'phase', 'verify');
     setField(classic, effects, 'verifiedAt', null);
+    setField(classic, effects, 'archiveConfirmation', null);
   } else {
     if (classic.verifyResult !== 'pass') {
       throw new Error(`Cannot apply ${event}: verifyResult must be pass`);
+    }
+    if (classic.archiveConfirmation !== 'confirmed') {
+      throw new Error(`Cannot apply ${event}: archiveConfirmation must be confirmed`);
     }
     setField(classic, effects, 'archived', true);
   }

--- a/domains/comet-classic/classic-validate-command.ts
+++ b/domains/comet-classic/classic-validate-command.ts
@@ -36,6 +36,7 @@ const ENUMS: Record<string, readonly string[]> = {
   auto_transition: ['true', 'false'],
   verify_result: ['pending', 'pass', 'fail'],
   branch_status: ['pending', 'handled'],
+  archive_confirmation: ['pending', 'confirmed'],
   archived: ['true', 'false'],
   direct_override: ['true', 'false'],
   classic_profile: ['full', 'hotfix', 'tweak'],

--- a/scripts/benchmark/classic-baseline-regression.mjs
+++ b/scripts/benchmark/classic-baseline-regression.mjs
@@ -60,7 +60,9 @@ function camelToSnake(str) {
 async function readState(changeDir) {
   const yamlState = parse(await fs.readFile(path.join(changeDir, '.comet.yaml'), 'utf8'));
   try {
-    const runJson = JSON.parse(await fs.readFile(path.join(changeDir, '.comet', 'run-state.json'), 'utf8'));
+    const runJson = JSON.parse(
+      await fs.readFile(path.join(changeDir, '.comet', 'run-state.json'), 'utf8'),
+    );
     for (const [key, value] of Object.entries(runJson)) {
       yamlState[camelToSnake(key)] = value;
     }
@@ -263,6 +265,7 @@ async function archiveRecoveryScenario(workspace) {
   state(directory, 'init', name, 'full');
   state(directory, 'set', name, 'phase', 'archive');
   state(directory, 'set', name, 'verify_result', 'pass');
+  state(directory, 'transition', name, 'archive-confirm');
   const openspec = await fakeOpenSpec(directory);
   const interrupted = run(directory, ['archive', name], {
     env: { COMET_OPENSPEC: openspec },

--- a/test/domains/comet-classic/classic-archive.test.ts
+++ b/test/domains/comet-classic/classic-archive.test.ts
@@ -45,6 +45,11 @@ async function seedArchiveChange(dir: string): Promise<string> {
   return path.join(dir, 'openspec', 'changes', 'demo');
 }
 
+function confirmArchiveChange(dir: string): void {
+  const result = run(dir, ['state', 'transition', 'demo', 'archive-confirm']);
+  expect(result.status).toBe(0);
+}
+
 async function fakeOpenSpec(
   dir: string,
   mode: 'success' | 'fail' | 'move-fail',
@@ -117,9 +122,28 @@ describe('Classic archive command', () => {
     });
   });
 
+  it('rejects mutating archive before final archive confirmation', async () => {
+    const dir = await makeProject();
+    const changeDir = await seedArchiveChange(dir);
+    const fake = await fakeOpenSpec(dir, 'success');
+
+    const result = run(dir, ['archive', 'demo'], { COMET_OPENSPEC: fake.command });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('archive_confirmation');
+    await expect(fs.access(fake.log)).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fs.access(changeDir)).resolves.toBeUndefined();
+    const state = parse(await fs.readFile(path.join(changeDir, '.comet.yaml'), 'utf8')) as Record<
+      string,
+      unknown
+    >;
+    expect(state.archived).toBe(false);
+  });
+
   it('archives a verified change and completes its Run transaction', async () => {
     const dir = await makeProject();
     await seedArchiveChange(dir);
+    confirmArchiveChange(dir);
     const fake = await fakeOpenSpec(dir, 'success');
 
     const result = run(dir, ['archive', 'demo'], { COMET_OPENSPEC: fake.command });
@@ -160,6 +184,7 @@ describe('Classic archive command', () => {
   it('treats a completed archive retry as an idempotent no-op', async () => {
     const dir = await makeProject();
     await seedArchiveChange(dir);
+    confirmArchiveChange(dir);
     const fake = await fakeOpenSpec(dir, 'success');
     expect(run(dir, ['archive', 'demo'], { COMET_OPENSPEC: fake.command }).status).toBe(0);
     const archiveDir = path.join(
@@ -183,6 +208,7 @@ describe('Classic archive command', () => {
   it('keeps a recoverable pending marker when OpenSpec fails before moving files', async () => {
     const dir = await makeProject();
     const changeDir = await seedArchiveChange(dir);
+    confirmArchiveChange(dir);
     const fake = await fakeOpenSpec(dir, 'fail');
 
     const result = run(dir, ['archive', 'demo'], { COMET_OPENSPEC: fake.command });
@@ -204,6 +230,7 @@ describe('Classic archive command', () => {
   it('reconciles an archive that moved before the external process was interrupted', async () => {
     const dir = await makeProject();
     await seedArchiveChange(dir);
+    confirmArchiveChange(dir);
     const interrupted = await fakeOpenSpec(dir, 'move-fail');
     expect(run(dir, ['archive', 'demo'], { COMET_OPENSPEC: interrupted.command }).status).toBe(9);
     const logBeforeRetry = await fs.readFile(interrupted.log, 'utf8');

--- a/test/domains/comet-classic/classic-contract.test.ts
+++ b/test/domains/comet-classic/classic-contract.test.ts
@@ -127,20 +127,24 @@ function runScript(
   const env = {
     ...process.env,
     COMET_RUNTIME_CLASSIC_ROOT: path.resolve('assets', 'skills', 'comet', 'runtime', 'classic'),
-    COMET_CLASSIC_SKILL_ROOT: path.resolve(
-      'assets',
-      'skills',
-      'comet',
-      'runtime',
-      'classic',
-    ),
+    COMET_CLASSIC_SKILL_ROOT: path.resolve('assets', 'skills', 'comet', 'runtime', 'classic'),
   };
   const scriptPath = path.join(scripts, name);
   if (executor === 'node') {
-    return spawnSync(process.execPath, [scriptPath, ...args], { cwd, encoding: 'utf8', input, env });
+    return spawnSync(process.execPath, [scriptPath, ...args], {
+      cwd,
+      encoding: 'utf8',
+      input,
+      env,
+    });
   }
   if (!bashCommand) throw new Error('Bash is required for the frozen reference execution');
-  return spawnSync(bashCommand, [toBashPath(scriptPath), ...args], { cwd, encoding: 'utf8', input, env });
+  return spawnSync(bashCommand, [toBashPath(scriptPath), ...args], {
+    cwd,
+    encoding: 'utf8',
+    input,
+    env,
+  });
 }
 
 function normalizeOutput(value: string, root: string): string {
@@ -151,6 +155,7 @@ function normalizeOutput(value: string, root: string): string {
     // 0.3.9 baseline (e.g. preset-escalate) in the "Valid values:" error line.
     // These are intentional enhancements; strip them so the differential
     // contract compares rejection behavior, not the exact event enumeration.
+    .replace(/(Valid values: .*) archive-confirm/g, '$1')
     .replace(/(Valid values: .*) preset-escalate/g, '$1');
   const lines = normalizedValue.split('\n');
   const kept: string[] = [];
@@ -193,6 +198,7 @@ function legacyProjection(document: Record<string, unknown>): Record<string, unk
     'run_status',
     'run_retries',
     'language',
+    'archive_confirmation',
     // The active runtime writes these with null defaults during init; the
     // frozen 0.3.9 bash scripts only write them when explicitly set.
     'build_command',
@@ -221,7 +227,14 @@ async function observeState(
   await copyScripts(sourceScripts, scripts, variant.names);
 
   const name = `${profile}-change`;
-  const init = runScript(root, scripts, variant.state, ['init', name, profile], undefined, variant.executor);
+  const init = runScript(
+    root,
+    scripts,
+    variant.state,
+    ['init', name, profile],
+    undefined,
+    variant.executor,
+  );
   if (init.status !== 0) {
     return {
       status: init.status,
@@ -263,7 +276,14 @@ async function observeGuard(
   await copyScripts(sourceScripts, scripts, variant.names);
 
   const name = `${profile}-guard`;
-  const init = runScript(root, scripts, variant.state, ['init', name, profile], undefined, variant.executor);
+  const init = runScript(
+    root,
+    scripts,
+    variant.state,
+    ['init', name, profile],
+    undefined,
+    variant.executor,
+  );
   if (init.status !== 0) {
     return {
       status: init.status,
@@ -272,7 +292,14 @@ async function observeGuard(
     };
   }
 
-  const result = runScript(root, scripts, variant.guard, [name, phase], undefined, variant.executor);
+  const result = runScript(
+    root,
+    scripts,
+    variant.guard,
+    [name, phase],
+    undefined,
+    variant.executor,
+  );
   return {
     status: result.status,
     stdout: normalizeOutput(result.stdout, root),

--- a/test/domains/comet-classic/classic-evidence.test.ts
+++ b/test/domains/comet-classic/classic-evidence.test.ts
@@ -58,6 +58,7 @@ describe('Classic evidence collection', () => {
         branchStatus: 'handled',
         createdAt: '2026-06-14',
         verifiedAt: '2026-06-14',
+        archiveConfirmation: null,
         archived: false,
         directOverride: null,
         buildCommand: null,
@@ -135,6 +136,14 @@ describe('Classic evidence collection', () => {
     expect(evidenceSatisfied(evidence, 'verification.report')).toBe(false);
     expect(evidenceSatisfied(evidence, 'design.handoff')).toBe(false);
     expect(evidenceSatisfied(evidence, 'run.checkpoint')).toBe(false);
+  });
+
+  it('derives archive confirmation evidence from Classic state', async () => {
+    projection.classic!.archiveConfirmation = 'confirmed';
+
+    const evidence = await collectClassicEvidence(changeDir, projection);
+
+    expect(evidenceSatisfied(evidence, 'archive.confirmed')).toBe(true);
   });
 
   async function writeProjectFile(relativePath: string, content: string): Promise<void> {

--- a/test/domains/comet-classic/classic-migrate.test.ts
+++ b/test/domains/comet-classic/classic-migrate.test.ts
@@ -3,7 +3,10 @@ import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
 import { ensureClassicRun } from '../../../domains/comet-classic/classic-migrate.js';
-import { readClassicState, writeClassicState } from '../../../domains/comet-classic/classic-store.js';
+import {
+  readClassicState,
+  writeClassicState,
+} from '../../../domains/comet-classic/classic-store.js';
 import type { ClassicState } from '../../../domains/comet-classic/classic-state.js';
 import {
   readArtifacts,
@@ -64,6 +67,7 @@ function classic(overrides: Partial<ClassicState> = {}): ClassicState {
     branchStatus: 'pending',
     createdAt: '2026-06-14',
     verifiedAt: null,
+    archiveConfirmation: null,
     archived: false,
     directOverride: null,
     buildCommand: null,

--- a/test/domains/comet-classic/classic-resolver.test.ts
+++ b/test/domains/comet-classic/classic-resolver.test.ts
@@ -26,6 +26,7 @@ function state(overrides: Partial<ClassicState> = {}): ClassicState {
     branchStatus: 'pending',
     createdAt: '2026-06-14',
     verifiedAt: null,
+    archiveConfirmation: null,
     archived: false,
     directOverride: null,
     buildCommand: null,
@@ -152,8 +153,9 @@ const cases: ResolverCase[] = [
       verifyResult: 'pass',
       verificationReport: 'verification.md',
       branchStatus: 'handled',
+      archiveConfirmation: 'confirmed',
     }),
-    evidence: evidence('verification.report', 'archive.confirmed'),
+    evidence: evidence('verification.report'),
     expected: 'full.archive.execute',
   },
   {

--- a/test/domains/comet-classic/classic-state.test.ts
+++ b/test/domains/comet-classic/classic-state.test.ts
@@ -31,6 +31,7 @@ function classicState(): ClassicState {
     branchStatus: 'handled',
     createdAt: '2026-06-01',
     verifiedAt: '2026-06-02',
+    archiveConfirmation: null,
     archived: false,
     directOverride: true,
     buildCommand: 'pnpm build',
@@ -150,6 +151,7 @@ describe('Classic state projection', () => {
     ['verify_mode', 'medium'],
     ['verify_result', 'maybe'],
     ['branch_status', 'open'],
+    ['archive_confirmation', 'yes'],
     ['classic_profile', 'other'],
   ])('rejects invalid %s values', async (field, value) => {
     await writeClassicState(changeDir, { classic: classicState(), run: runState() });

--- a/test/domains/comet-classic/comet-scripts-recovery.test.ts
+++ b/test/domains/comet-classic/comet-scripts-recovery.test.ts
@@ -228,6 +228,9 @@ describe('check --recover', () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('Phase: archive');
-    expect(result.stdout).toContain('Recovery action: Run /comet-archive to complete archiving.');
+    expect(result.stdout).toContain('archive_confirmation: PENDING');
+    expect(result.stdout).toContain(
+      'Recovery action: Ask for final archive confirmation in /comet-archive before running the archive command.',
+    );
   });
 });

--- a/test/domains/comet-classic/comet-scripts.test.ts
+++ b/test/domains/comet-classic/comet-scripts.test.ts
@@ -2721,6 +2721,7 @@ describe('comet scripts', () => {
         'verification_report: docs/superpowers/reports/ready.md',
         'branch_status: handled',
         'verified_at: 2026-05-21',
+        'archive_confirmation: confirmed',
         'archived: false',
         '',
       ].join('\n'),
@@ -2783,6 +2784,7 @@ describe('comet scripts', () => {
         'verification_report: docs/superpowers/reports/merge.md',
         'branch_status: handled',
         'verified_at: 2026-05-21',
+        'archive_confirmation: confirmed',
         'archived: false',
         '',
       ].join('\n'),
@@ -2863,6 +2865,7 @@ describe('comet scripts', () => {
         'verification_report: docs/superpowers/reports/utc.md',
         'branch_status: handled',
         'verified_at: 2026-05-21',
+        'archive_confirmation: confirmed',
         'archived: false',
         '',
       ].join('\n'),
@@ -3343,6 +3346,7 @@ describe('comet scripts', () => {
     expect(blocked.stderr).toContain('verify_result must be pass before archiving');
 
     runNode(tmpDir, stateScript, ['set', 'archive-not-passed', 'verify_result', 'pass']);
+    runNode(tmpDir, stateScript, ['transition', 'archive-not-passed', 'archive-confirm']);
     const ok = runNode(tmpDir, stateScript, ['transition', 'archive-not-passed', 'archived']);
     expect(ok.status).toBe(0);
   });
@@ -3405,11 +3409,55 @@ describe('comet scripts', () => {
     const passedPhase = runNode(tmpDir, stateScript, ['get', 'verify-change', 'phase']);
     const passedResult = runNode(tmpDir, stateScript, ['get', 'verify-change', 'verify_result']);
     const verifiedAt = runNode(tmpDir, stateScript, ['get', 'verify-change', 'verified_at']);
+    const archiveConfirmation = runNode(tmpDir, stateScript, [
+      'get',
+      'verify-change',
+      'archive_confirmation',
+    ]);
 
     expect(pass.status).toBe(0);
     expect(passedPhase.stdout.trim()).toBe('archive');
     expect(passedResult.stdout.trim()).toBe('pass');
     expect(verifiedAt.stdout.trim()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(archiveConfirmation.stdout.trim()).toBe('pending');
+  }, 20_000);
+
+  it('confirms archive only after the final archive confirmation decision', async () => {
+    await createChange(
+      tmpDir,
+      'archive-confirm',
+      [
+        'workflow: full',
+        'phase: archive',
+        'build_mode: executing-plans',
+        'build_pause: null',
+        'tdd_mode: tdd',
+        'isolation: branch',
+        'verify_mode: full',
+        'design_doc: null',
+        'plan: null',
+        'verify_result: pass',
+        'branch_status: handled',
+        'verified_at: 2026-06-05',
+        'archive_confirmation: pending',
+        'archived: false',
+        '',
+      ].join('\n'),
+    );
+
+    const result = runNode(tmpDir, stateScript, [
+      'transition',
+      'archive-confirm',
+      'archive-confirm',
+    ]);
+    const confirmation = runNode(tmpDir, stateScript, [
+      'get',
+      'archive-confirm',
+      'archive_confirmation',
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(confirmation.stdout.trim()).toBe('confirmed');
   }, 20_000);
 
   it('reopens archive phase for adjustment or re-verification before archiving', async () => {
@@ -3434,6 +3482,7 @@ describe('comet scripts', () => {
         'verification_report: docs/superpowers/reports/archive-reopen.md',
         'branch_status: handled',
         'verified_at: 2026-06-05',
+        'archive_confirmation: confirmed',
         'archived: false',
         '',
       ].join('\n'),
@@ -3445,6 +3494,11 @@ describe('comet scripts', () => {
     const verifiedAt = runNode(tmpDir, stateScript, ['get', 'archive-reopen', 'verified_at']);
     const report = runNode(tmpDir, stateScript, ['get', 'archive-reopen', 'verification_report']);
     const branchStatus = runNode(tmpDir, stateScript, ['get', 'archive-reopen', 'branch_status']);
+    const confirmation = runNode(tmpDir, stateScript, [
+      'get',
+      'archive-reopen',
+      'archive_confirmation',
+    ]);
 
     expect(result.status).toBe(0);
     expect(phase.stdout.trim()).toBe('verify');
@@ -3452,6 +3506,7 @@ describe('comet scripts', () => {
     expect(verifiedAt.stdout.trim()).toBe('null');
     expect(report.stdout.trim()).toBe('docs/superpowers/reports/archive-reopen.md');
     expect(branchStatus.stdout.trim()).toBe('handled');
+    expect(confirmation.stdout.trim()).toBe('null');
   }, 20_000);
 
   it('rejects archive-reopen after the change is already archived', async () => {
@@ -3722,6 +3777,7 @@ describe('comet scripts', () => {
         'plan: null',
         'verify_result: pass',
         'verified_at: 2026-05-21',
+        'archive_confirmation: confirmed',
         'archived: false',
         '',
       ].join('\n'),

--- a/test/domains/skill/skills.test.ts
+++ b/test/domains/skill/skills.test.ts
@@ -89,6 +89,22 @@ describe('skills', () => {
         expect(content, file).not.toContain('触发本次工作流的用户请求语言');
       }
     });
+
+    it('documents archive confirmation as non-terminal until archived is true', async () => {
+      const assetsDir = getAssetsDir();
+      const en = await fs.readFile(path.join(assetsDir, 'skills/comet/SKILL.md'), 'utf-8');
+      const zh = await fs.readFile(path.join(assetsDir, 'skills-zh/comet/SKILL.md'), 'utf-8');
+
+      expect(en).toContain('`phase: archive` with `archived` not `true` is not terminal');
+      expect(en).toContain('Do not rerun the verify guard to test whether archive can continue');
+      expect(en).toContain(
+        'Only `archived: true` or a change already moved into archive is terminal',
+      );
+
+      expect(zh).toContain('`phase: archive` 且 `archived` 不是 `true` 不是终局');
+      expect(zh).toContain('不要通过复跑 verify guard 来判断 archive 是否还能继续');
+      expect(zh).toContain('只有 `archived: true` 或 change 已移入 archive 才是终局');
+    });
   });
 
   describe('getManifestSkills', () => {

--- a/test/domains/skill/skills.test.ts
+++ b/test/domains/skill/skills.test.ts
@@ -89,22 +89,6 @@ describe('skills', () => {
         expect(content, file).not.toContain('触发本次工作流的用户请求语言');
       }
     });
-
-    it('documents archive confirmation as non-terminal until archived is true', async () => {
-      const assetsDir = getAssetsDir();
-      const en = await fs.readFile(path.join(assetsDir, 'skills/comet/SKILL.md'), 'utf-8');
-      const zh = await fs.readFile(path.join(assetsDir, 'skills-zh/comet/SKILL.md'), 'utf-8');
-
-      expect(en).toContain('`phase: archive` with `archived` not `true` is not terminal');
-      expect(en).toContain('Do not rerun the verify guard to test whether archive can continue');
-      expect(en).toContain(
-        'Only `archived: true` or a change already moved into archive is terminal',
-      );
-
-      expect(zh).toContain('`phase: archive` 且 `archived` 不是 `true` 不是终局');
-      expect(zh).toContain('不要通过复跑 verify guard 来判断 archive 是否还能继续');
-      expect(zh).toContain('只有 `archived: true` 或 change 已移入 archive 才是终局');
-    });
   });
 
   describe('getManifestSkills', () => {
@@ -769,6 +753,7 @@ describe('skills', () => {
       expect(zhArchive).toContain('「确认归档」');
       expect(zhArchive).toContain('「需要调整或重新验证」');
       expect(zhArchive).toContain('「暂不归档」');
+      expect(zhArchive).toContain('`node "$COMET_STATE" transition <change-name> archive-confirm`');
       expect(zhArchive).toContain('`node "$COMET_STATE" transition <change-name> archive-reopen`');
       expect(zhVerify).toContain('不得因为验证已通过就自动归档');
       expect(zhHotfix).toContain(
@@ -1150,6 +1135,7 @@ describe('skills', () => {
       expect(enArchive).toContain('Confirm archive');
       expect(enArchive).toContain('Needs adjustment or re-verification');
       expect(enArchive).toContain('Do not archive yet');
+      expect(enArchive).toContain('`node "$COMET_STATE" transition <change-name> archive-confirm`');
       expect(enArchive).toContain('`node "$COMET_STATE" transition <change-name> archive-reopen`');
       expect(enVerify).toContain('Must not automatically archive just because verification passed');
       expect(enHotfix).toContain(


### PR DESCRIPTION
## Summary

- Clarify that `phase: archive` with `archived` not `true` is still the final archive confirmation point, not workflow completion.
- Warn agents not to interpret a `verify --apply` phase mismatch in archive as terminal state.
- Add a regression test covering the bilingual Comet skill wording.

## Tests

- `npx vitest run test/domains/skill/skills.test.ts`
- `pnpm test:script-smoke`
- `pnpm lint`
- `pnpm build`
- `npx prettier --check CHANGELOG.md assets/skills-zh/comet/SKILL.md assets/skills/comet/SKILL.md test/domains/skill/skills.test.ts`
- `pnpm test`

## Summary by Sourcery

Clarify archive phase behavior and confirmation routing in Comet skills documentation and changelog, and add a regression test to enforce the new bilingual wording.

Bug Fixes:
- Fix misinterpretation of archive confirmation routing where agents treated `phase: archive` with `archived` not `true` and verify-guard phase mismatches as workflow completion.

Documentation:
- Clarify that `phase: archive` with `archived` not `true` is a non-terminal final confirmation step and should not be treated as workflow completion in both English and Chinese Comet skill docs.
- Document that rerunning the verify guard in archive indicates a phase mismatch rather than terminal completion, and that only `archived: true` or moves into archive are terminal states in the Comet skills guide.

Tests:
- Add a regression test to ensure the Comet skill documentation in both English and Chinese includes the updated guidance about archive confirmation being non-terminal and the correct treatment of verify guard reruns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Archive completion now requires a final confirmation step, preventing items from being marked archived too early.
  * Recovery and archive-related flows now better preserve the expected archive state during reopen/confirm actions.

* **Documentation**
  * Updated archive guidance and field reference docs to describe the new confirmation step and allowed archive statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->