### PR TITLE
fix: install only the selected language's Comet rule file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to @rpamis/comet will be documented in this file.
 
+## What's Changed [0.4.0-beta.2] - 2026-07-07
+
+### Fixed
+
+- **Single-language rule install**: `comet init` and `comet update` now install only the Comet phase-guard rule file matching the selected/detected Skill language (e.g. `.claude/rules/comet-phase-guard.md`), instead of always installing both the Chinese and English rule variants side by side regardless of language choice.
+
 ## What's Changed [0.4.0-beta.1] - 2026-07-06
 
 This is the first beta of the 0.4.0 line. Relative to 0.3.9, Comet becomes a cross-platform Node runtime and expands from a `/comet` workflow bundle into a workflow, Skill creation, eval, and dashboard platform. The notes below describe the final user-visible release shape, not the branch work history.

--- a/app/commands/init.ts
+++ b/app/commands/init.ts
@@ -519,6 +519,7 @@ export async function initCommand(targetPath: string, options: InitOptions = {})
         baseDir,
         platform,
         cmAction === 'overwrite',
+        language.id,
         scope,
       );
       if (ruleCopied > 0) {

--- a/app/commands/update.ts
+++ b/app/commands/update.ts
@@ -50,8 +50,15 @@ interface DetectTargetsOptions {
   globalBaseDir?: string;
 }
 
+function resolveTargetLanguage(
+  language: string | undefined,
+  fallback: SkillLanguage,
+): SkillLanguage {
+  return (language ?? fallback) === 'zh' ? 'zh' : 'en';
+}
+
 function languageToSkillsDir(language: string | undefined, fallback: SkillLanguage): string {
-  return (language ?? fallback) === 'zh' ? 'skills-zh' : 'skills';
+  return resolveTargetLanguage(language, fallback) === 'zh' ? 'skills-zh' : 'skills';
 }
 
 function getScopedBaseDir(
@@ -340,6 +347,7 @@ export async function updateCommand(
   for (const target of targets) {
     const baseDir = getBaseDir(target.scope, projectPath);
     const languageSkillsDir = languageToSkillsDir(options.language, target.language);
+    const languageId = resolveTargetLanguage(options.language, target.language);
     const { copied, skipped } = await copyCometSkillsForPlatform(
       baseDir,
       target.platform,
@@ -373,6 +381,7 @@ export async function updateCommand(
         baseDir,
         target.platform,
         true,
+        languageId,
         target.scope,
       );
       totalRulesCopied += ruleCopied;

--- a/app/commands/update.ts
+++ b/app/commands/update.ts
@@ -57,8 +57,8 @@ function resolveTargetLanguage(
   return (language ?? fallback) === 'zh' ? 'zh' : 'en';
 }
 
-function languageToSkillsDir(language: string | undefined, fallback: SkillLanguage): string {
-  return resolveTargetLanguage(language, fallback) === 'zh' ? 'skills-zh' : 'skills';
+function languageToSkillsDir(languageId: SkillLanguage): string {
+  return languageId === 'zh' ? 'skills-zh' : 'skills';
 }
 
 function getScopedBaseDir(
@@ -329,7 +329,8 @@ export async function updateCommand(
   for (const target of targets) {
     const language = options.language ?? target.language;
     const scopeLabel = target.scope === 'global' ? 'global' : `project (${projectPath})`;
-    const languageSkillsDir = languageToSkillsDir(options.language, target.language);
+    const languageId = resolveTargetLanguage(options.language, target.language);
+    const languageSkillsDir = languageToSkillsDir(languageId);
     log(`    - ${target.platform.name} (${scopeLabel}, ${language})`);
     log(
       `      $ ${formatSkillUpdateCommand(target.scope, target.platform, languageSkillsDir, installMode)}`,
@@ -346,8 +347,8 @@ export async function updateCommand(
   const targetResults = [];
   for (const target of targets) {
     const baseDir = getBaseDir(target.scope, projectPath);
-    const languageSkillsDir = languageToSkillsDir(options.language, target.language);
     const languageId = resolveTargetLanguage(options.language, target.language);
+    const languageSkillsDir = languageToSkillsDir(languageId);
     const { copied, skipped } = await copyCometSkillsForPlatform(
       baseDir,
       target.platform,

--- a/domains/skill/platform-install.ts
+++ b/domains/skill/platform-install.ts
@@ -454,6 +454,17 @@ async function getManifestSkills(): Promise<string[]> {
  */
 // Rule variants share a base name and differ only by a `.en.md` suffix
 // (e.g. `comet-phase-guard.md` = zh default, `comet-phase-guard.en.md` = en).
+// Centralized here so the naming convention only needs to change in one place.
+const EN_RULE_SUFFIX = /\.en\.md$/;
+
+function isEnglishRuleVariant(ruleRelPath: string): boolean {
+  return EN_RULE_SUFFIX.test(ruleRelPath);
+}
+
+function toRuleBaseName(ruleRelPath: string): string {
+  return ruleRelPath.replace(EN_RULE_SUFFIX, '.md');
+}
+
 // Pick exactly one variant per base name for the requested language, falling
 // back to whichever variant exists if there's no per-language pair.
 function selectRulePathsForLanguage(rulePaths: string[], languageId: SkillLanguageId): string[] {
@@ -461,8 +472,8 @@ function selectRulePathsForLanguage(rulePaths: string[], languageId: SkillLangua
   const selected = new Map<string, { rulePath: string; matched: boolean }>();
 
   for (const rulePath of rulePaths) {
-    const isEnglishVariant = rulePath.endsWith('.en.md');
-    const baseKey = isEnglishVariant ? rulePath.replace(/\.en\.md$/, '.md') : rulePath;
+    const isEnglishVariant = isEnglishRuleVariant(rulePath);
+    const baseKey = toRuleBaseName(rulePath);
     const matched = isEnglishVariant === wantEnglish;
     const existing = selected.get(baseKey);
 
@@ -512,7 +523,7 @@ async function copyCometRulesForPlatform(
 
     // Normalize the `.en` infix away so the installed file name is the same
     // regardless of which language variant was selected.
-    const ruleFileName = path.basename(ruleRelPath).replace(/\.en\.md$/, '.md');
+    const ruleFileName = toRuleBaseName(path.basename(ruleRelPath));
     const rulesDestDir = path.join(rulesBase, platform.rulesDir);
     const dest = computeRuleDestPath(rulesDestDir, ruleFileName, platform.rulesFormat);
 

--- a/domains/skill/platform-install.ts
+++ b/domains/skill/platform-install.ts
@@ -8,7 +8,7 @@ import { fileExists, readJson, copyFile, ensureDir } from '../../platform/fs/fil
 import { getPlatformSkillsDir, type Platform } from '../../platform/install/platforms.js';
 import type { InstallScope, InstallMode } from '../../platform/install/types.js';
 import { formatSupportedArtifactLanguages, resolveArtifactLanguage } from './languages.js';
-import type { LanguageConfig } from './languages.js';
+import type { LanguageConfig, SkillLanguageId } from './languages.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -452,10 +452,33 @@ async function getManifestSkills(): Promise<string[]> {
  *   'copilot' = GitHub Copilot .instructions.md with applyTo frontmatter
  * Skips platforms without rulesDir.
  */
+// Rule variants share a base name and differ only by a `.en.md` suffix
+// (e.g. `comet-phase-guard.md` = zh default, `comet-phase-guard.en.md` = en).
+// Pick exactly one variant per base name for the requested language, falling
+// back to whichever variant exists if there's no per-language pair.
+function selectRulePathsForLanguage(rulePaths: string[], languageId: SkillLanguageId): string[] {
+  const wantEnglish = languageId === 'en';
+  const selected = new Map<string, { rulePath: string; matched: boolean }>();
+
+  for (const rulePath of rulePaths) {
+    const isEnglishVariant = rulePath.endsWith('.en.md');
+    const baseKey = isEnglishVariant ? rulePath.replace(/\.en\.md$/, '.md') : rulePath;
+    const matched = isEnglishVariant === wantEnglish;
+    const existing = selected.get(baseKey);
+
+    if (!existing || (matched && !existing.matched)) {
+      selected.set(baseKey, { rulePath, matched });
+    }
+  }
+
+  return [...selected.values()].map((entry) => entry.rulePath);
+}
+
 async function copyCometRulesForPlatform(
   baseDir: string,
   platform: Platform,
   overwrite: boolean,
+  languageId: SkillLanguageId,
   scope: InstallScope = 'project',
 ): Promise<{ copied: number; skipped: number }> {
   if (!platform.rulesDir || !platform.rulesFormat) {
@@ -463,7 +486,7 @@ async function copyCometRulesForPlatform(
   }
 
   const manifest = await readManifest();
-  const rulePaths = manifest.rules;
+  const rulePaths = selectRulePathsForLanguage(manifest.rules ?? [], languageId);
   if (!rulePaths || rulePaths.length === 0) {
     return { copied: 0, skipped: 0 };
   }
@@ -487,7 +510,9 @@ async function copyCometRulesForPlatform(
       continue;
     }
 
-    const ruleFileName = path.basename(ruleRelPath);
+    // Normalize the `.en` infix away so the installed file name is the same
+    // regardless of which language variant was selected.
+    const ruleFileName = path.basename(ruleRelPath).replace(/\.en\.md$/, '.md');
     const rulesDestDir = path.join(rulesBase, platform.rulesDir);
     const dest = computeRuleDestPath(rulesDestDir, ruleFileName, platform.rulesFormat);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rpamis/comet",
-  "version": "0.4.0-beta.1",
+  "version": "0.4.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rpamis/comet",
-      "version": "0.4.0-beta.1",
+      "version": "0.4.0-beta.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rpamis/comet",
-  "version": "0.4.0-beta.1",
+  "version": "0.4.0-beta.2",
   "description": "Agent Skill Harness Phase-Guarded Automation From Idea To Archive",
   "keywords": [
     "comet",

--- a/test/app/init-e2e.test.ts
+++ b/test/app/init-e2e.test.ts
@@ -558,6 +558,38 @@ describe('comet init E2E', () => {
   );
 
   it(
+    'installs only the zh Comet rule variant when initialized with language zh',
+    async () => {
+      mockExternalSuccess();
+
+      await fs.mkdir(path.join(tmpDir, '.zcode'), { recursive: true });
+      const fakeHome = path.join(tmpDir, 'fake-home');
+      await fs.mkdir(fakeHome, { recursive: true });
+
+      vi.spyOn(os, 'homedir').mockReturnValue(fakeHome);
+
+      const { initCommand } = await import('../../app/commands/init.js');
+      const result = await captureJsonOutput(() =>
+        initCommand(tmpDir, { yes: true, scope: 'global', json: true, language: 'zh' }),
+      );
+
+      expect(result.selectedPlatforms).toEqual(['zcode']);
+
+      // With zh selected, only the normalized zh rule file should be installed —
+      // the .en.md variant must not appear alongside it.
+      const ruleDest = path.join(fakeHome, '.zcode', 'rules', 'comet-phase-guard.md');
+      await expect(fs.access(ruleDest)).resolves.toBeUndefined();
+      const ruleContent = await fs.readFile(ruleDest, 'utf-8');
+      expect(ruleContent).toContain('Comet 阶段感知');
+
+      await expect(
+        fs.access(path.join(fakeHome, '.zcode', 'rules', 'comet-phase-guard.en.md')),
+      ).rejects.toThrow();
+    },
+    INIT_E2E_TIMEOUT_MS,
+  );
+
+  it(
     'summarizes partial OpenCode failures by failed component only once',
     async () => {
       mockedExecFileSync.mockImplementation((command: unknown, args?: unknown) => {

--- a/test/app/init-e2e.test.ts
+++ b/test/app/init-e2e.test.ts
@@ -538,11 +538,17 @@ describe('comet init E2E', () => {
         await expect(fs.access(dest)).resolves.toBeUndefined();
       }
 
-      // Comet rules are also distributed to the platform rules directory
-      for (const rulePath of manifest.rules ?? []) {
-        const dest = path.join(fakeHome, '.zcode', 'rules', path.basename(rulePath));
-        await expect(fs.access(dest)).resolves.toBeUndefined();
-      }
+      // Comet rules are distributed to the platform rules directory, but only
+      // the selected language's variant (default init selects English here) —
+      // not every language variant listed in the manifest.
+      const ruleDest = path.join(fakeHome, '.zcode', 'rules', 'comet-phase-guard.md');
+      await expect(fs.access(ruleDest)).resolves.toBeUndefined();
+      const ruleContent = await fs.readFile(ruleDest, 'utf-8');
+      expect(ruleContent).toContain('Comet Phase Awareness');
+
+      await expect(
+        fs.access(path.join(fakeHome, '.zcode', 'rules', 'comet-phase-guard.en.md')),
+      ).rejects.toThrow();
 
       await expect(
         fs.access(path.join(tmpDir, '.zcode', 'skills', 'comet', 'SKILL.md')),

--- a/test/app/uninstall.test.ts
+++ b/test/app/uninstall.test.ts
@@ -192,7 +192,7 @@ describe('uninstall', () => {
     it('removes rules for a platform that supports them', async () => {
       const claudePlatform: Platform = PLATFORMS.find((p) => p.id === 'claude')!;
 
-      await copyCometRulesForPlatform(tmpDir, claudePlatform, true, 'project');
+      await copyCometRulesForPlatform(tmpDir, claudePlatform, true, 'zh', 'project');
 
       const rulePath = path.join(tmpDir, '.claude', 'rules', 'comet-phase-guard.md');
       expect(await fileExists(rulePath)).toBe(true);
@@ -205,7 +205,7 @@ describe('uninstall', () => {
     it('removes Cursor MDC format rules', async () => {
       const cursorPlatform: Platform = PLATFORMS.find((p) => p.id === 'cursor')!;
 
-      await copyCometRulesForPlatform(tmpDir, cursorPlatform, true, 'project');
+      await copyCometRulesForPlatform(tmpDir, cursorPlatform, true, 'zh', 'project');
 
       const rulePath = path.join(tmpDir, '.cursor', 'rules', 'comet-phase-guard.mdc');
       expect(await fileExists(rulePath)).toBe(true);
@@ -218,7 +218,7 @@ describe('uninstall', () => {
     it('removes GitHub Copilot instructions format', async () => {
       const copilotPlatform: Platform = PLATFORMS.find((p) => p.id === 'github-copilot')!;
 
-      await copyCometRulesForPlatform(tmpDir, copilotPlatform, true, 'project');
+      await copyCometRulesForPlatform(tmpDir, copilotPlatform, true, 'zh', 'project');
 
       const rulePath = path.join(
         tmpDir,
@@ -390,7 +390,7 @@ describe('uninstall', () => {
 
       // Install everything
       await copyCometSkillsForPlatform(tmpDir, claudePlatform, true, 'skills', 'project');
-      await copyCometRulesForPlatform(tmpDir, claudePlatform, true, 'project');
+      await copyCometRulesForPlatform(tmpDir, claudePlatform, true, 'zh', 'project');
       await installCometHooksForPlatform(tmpDir, claudePlatform, 'project');
 
       // Verify installation


### PR DESCRIPTION
## Summary
- `copyCometRulesForPlatform` used to copy every rule file listed in `manifest.rules` (`comet-phase-guard.md` zh + `comet-phase-guard.en.md` en) unconditionally, so `comet init`/`comet update` always installed both language variants of the phase-guard rule regardless of the selected/detected Skill language.
- It now selects only the rule variant matching the selected/detected language id and normalizes the installed file name so the destination path is identical across languages (e.g. `.claude/rules/comet-phase-guard.md`).
- Refactored the language check to compare against the proper `SkillLanguageId`/`SkillLanguage` id ('en' | 'zh') instead of comparing the skills directory name string, for clarity and type safety.

## Test plan
- [x] `test/app/init-e2e.test.ts` updated to assert only the selected language's rule file is installed (was asserting both files existed).
- [x] `npx tsc --noEmit`
- [x] `pnpm build && pnpm lint && pnpm format:check`
- [x] `pnpm test` (1032/1033 passing; the 1 pre-existing failure is unrelated to this change — a malformed YAML frontmatter in an unrelated local global skill config, reproducible on master before this change too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Install language-specific Comet phase-guard rules and align rule selection with the chosen skill language during init and update commands.

Bug Fixes:
- Ensure only the selected/detected language variant of the Comet phase-guard rule is installed instead of all manifest rule variants.

Enhancements:
- Normalize installed Comet rule filenames across languages so the destination path is consistent regardless of language.
- Refine language resolution in update workflows to use explicit skill language identifiers for clearer and safer targeting of language-specific assets.

Build:
- Bump package version from 0.4.0-beta.1 to 0.4.0-beta.2.

Documentation:
- Add changelog entry for version 0.4.0-beta.2 describing the single-language Comet rule installation behavior.

Tests:
- Update init end-to-end tests to assert only the selected language’s rule file is installed and contains the expected English content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `comet init` and `comet update` to install only the Comet phase-guard rule matching the selected/detected language, instead of installing multiple language variants together.
  * Kept the installed rule filename consistent across language variants.
  * Improved ZCode initialization checks to confirm the correct localized rule is present and the other variant is not.
* **Chores**
  * Bumped the release version to `0.4.0-beta.2`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->