### PR TITLE
fix: protect installs and artifact routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to @rpamis/comet will be documented in this file.
 
+## What's Changed [0.4.0-beta.2] - 2026-07-07
+
+### Fixed
+
+- **Symlink install safety**: `comet init` and `comet update` now refuse to replace an existing platform `skills/` directory with a symlink when it contains files outside Comet's managed manifest, preserving local or third-party Skills instead of deleting them during symlink-mode installs ([#159](https://github.com/rpamis/comet/issues/159)).
+- **Parallel change artifact writes**: Classic phase guards now route `docs/superpowers/` writes to the matching design/build/verify change instead of letting an unrelated earlier active change block shared Design Doc and planning artifacts ([#160](https://github.com/rpamis/comet/issues/160)).
+
 ## What's Changed [0.4.0-beta.1] - 2026-07-06
 
 This is the first beta of the 0.4.0 line. Relative to 0.3.9, Comet becomes a cross-platform Node runtime and expands from a `/comet` workflow bundle into a workflow, Skill creation, eval, and dashboard platform. The notes below describe the final user-visible release shape, not the branch work history.

--- a/assets/skills/comet/scripts/comet-runtime.mjs
+++ b/assets/skills/comet/scripts/comet-runtime.mjs
@@ -11278,6 +11278,39 @@ function blocksSourceWrites(governing) {
   }
   return governing.phase === "build" && governing.classic?.workflow === "full" && !governing.classic.designDoc;
 }
+function isSuperpowersArtifactPath(relativePath2) {
+  return relativePath2.startsWith("docs/superpowers/");
+}
+function allowsSuperpowersArtifacts(governing) {
+  return governing.phase === "design" || governing.phase === "build" || governing.phase === "verify";
+}
+function governingChangeName(governing) {
+  return governing.changeDir ? path16.basename(governing.changeDir) : null;
+}
+function matchesRecordedSuperpowersArtifact(relativePath2, governing) {
+  const artifactPaths = [
+    governing.classic?.designDoc,
+    governing.classic?.plan,
+    governing.classic?.verificationReport
+  ];
+  return artifactPaths.some(
+    (artifactPath) => artifactPath && normalized(artifactPath) === relativePath2
+  );
+}
+async function superpowersArtifactGoverningChange(relativePath2, projectRoot) {
+  const active = await activeChanges(projectRoot);
+  const recorded = active.find(
+    (governing) => matchesRecordedSuperpowersArtifact(relativePath2, governing)
+  );
+  if (recorded) return recorded;
+  const eligible = active.filter(allowsSuperpowersArtifacts);
+  const named = eligible.find((governing) => {
+    const name = governingChangeName(governing);
+    return name !== null && relativePath2.includes(name);
+  });
+  if (named) return named;
+  return eligible[0] ?? null;
+}
 async function repoSourceGoverningChange(projectRoot) {
   const active = await activeChanges(projectRoot);
   return active.find(blocksSourceWrites) ?? active[0] ?? null;
@@ -11297,6 +11330,9 @@ async function governingChange(relativePath2, projectRoot) {
       }
       return { changeDir, phase: "open", classic: null, archived: false };
     }
+  }
+  if (isSuperpowersArtifactPath(relativePath2)) {
+    return await superpowersArtifactGoverningChange(relativePath2, projectRoot) ?? repoSourceGoverningChange(projectRoot);
   }
   return repoSourceGoverningChange(projectRoot);
 }
@@ -11414,7 +11450,7 @@ var classicHookGuardCommand = async (args) => {
   const phase = governing.phase;
   const openSpec = openSpecAllowed(relativePath2, phase);
   if (openSpec) return allowed(openSpec);
-  if (relativePath2.startsWith("docs/superpowers/") && (phase === "design" || phase === "build" || phase === "verify")) {
+  if (isSuperpowersArtifactPath(relativePath2) && (phase === "design" || phase === "build" || phase === "verify")) {
     return allowed(`${relativePath2} (phase: ${phase}, superpowers)`);
   }
   if (phase === "build" && governing.classic?.workflow === "full" && !governing.classic.designDoc) {

--- a/assets/skills/comet/scripts/comet-runtime.mjs
+++ b/assets/skills/comet/scripts/comet-runtime.mjs
@@ -11354,8 +11354,9 @@ async function governingChange(relativePath2, projectRoot) {
   }
   if (isSuperpowersArtifactPath(relativePath2)) {
     const superpowers = await superpowersArtifactGoverningChange(relativePath2, projectRoot);
-    if (superpowers) return superpowers;
-    return repoSourceGoverningChange(projectRoot);
+    if (superpowers) return { ...superpowers, superpowersArtifact: "matched" };
+    const fallback = await repoSourceGoverningChange(projectRoot);
+    return fallback ? { ...fallback, superpowersArtifact: "unmatched" } : null;
   }
   return repoSourceGoverningChange(projectRoot);
 }
@@ -11442,6 +11443,25 @@ function blockedMissingDesignDoc(relativePath2) {
     ].join("\n")
   );
 }
+function blockedUnmatchedSuperpowersArtifact(relativePath2, phase) {
+  return result(
+    2,
+    [
+      "",
+      "╔══════════════════════════════════════════╗",
+      "║     COMET PHASE GUARD — WRITE BLOCKED    ║",
+      "╚══════════════════════════════════════════╝",
+      "",
+      `  Current phase: ${phase}`,
+      `  Target file: ${relativePath2}`,
+      "",
+      "  BLOCKED: unmatched Superpowers artifact",
+      "  This docs/superpowers/ path does not match any active change artifact",
+      "  NEXT: record the artifact path in .comet.yaml or include the change name in the artifact filename",
+      ""
+    ].join("\n")
+  );
+}
 var classicHookGuardCommand = async (args) => {
   const projectRoot = parseProjectRoot(args);
   const target = inputTarget();
@@ -11473,8 +11493,13 @@ var classicHookGuardCommand = async (args) => {
   const phase = governing.phase;
   const openSpec = openSpecAllowed(relativePath2, phase);
   if (openSpec) return allowed(openSpec);
-  if (isSuperpowersArtifactPath(relativePath2) && allowsSuperpowersArtifacts(governing)) {
-    return allowed(`${relativePath2} (phase: ${phase}, superpowers)`);
+  if (isSuperpowersArtifactPath(relativePath2)) {
+    if (governing.superpowersArtifact === "matched" && allowsSuperpowersArtifacts(governing)) {
+      return allowed(`${relativePath2} (phase: ${phase}, superpowers)`);
+    }
+    if (governing.superpowersArtifact === "unmatched") {
+      return blockedUnmatchedSuperpowersArtifact(relativePath2, phase);
+    }
   }
   if (phase === "build" && governing.classic?.workflow === "full" && !governing.classic.designDoc) {
     return blockedMissingDesignDoc(relativePath2);

--- a/assets/skills/comet/scripts/comet-runtime.mjs
+++ b/assets/skills/comet/scripts/comet-runtime.mjs
@@ -11287,6 +11287,14 @@ function allowsSuperpowersArtifacts(governing) {
 function governingChangeName(governing) {
   return governing.changeDir ? path16.basename(governing.changeDir) : null;
 }
+var SUPERPOWERS_ARTIFACT_SUFFIXES = /* @__PURE__ */ new Set([
+  "design",
+  "plan",
+  "verify",
+  "verification",
+  "verification-report",
+  "report"
+]);
 function matchesRecordedSuperpowersArtifact(relativePath2, governing) {
   const artifactPaths = [
     governing.classic?.designDoc,
@@ -11297,6 +11305,18 @@ function matchesRecordedSuperpowersArtifact(relativePath2, governing) {
     (artifactPath) => artifactPath && normalized(artifactPath) === relativePath2
   );
 }
+function matchesSuperpowersArtifactName(relativePath2, changeName) {
+  const fileName = relativePath2.split("/").at(-1) ?? relativePath2;
+  const stem = fileName.replace(/\.[^.]+$/u, "");
+  if (stem === changeName) return true;
+  for (const separator of ["-", "_", "."]) {
+    const prefix = `${changeName}${separator}`;
+    if (!stem.startsWith(prefix)) continue;
+    const suffix = stem.slice(prefix.length);
+    if (SUPERPOWERS_ARTIFACT_SUFFIXES.has(suffix)) return true;
+  }
+  return false;
+}
 async function superpowersArtifactGoverningChange(relativePath2, projectRoot) {
   const active = await activeChanges(projectRoot);
   const recorded = active.find(
@@ -11304,10 +11324,12 @@ async function superpowersArtifactGoverningChange(relativePath2, projectRoot) {
   );
   if (recorded) return recorded;
   const eligible = active.filter(allowsSuperpowersArtifacts);
-  const named = eligible.find((governing) => {
+  const named = eligible.filter((governing) => {
     const name = governingChangeName(governing);
-    return name !== null && relativePath2.includes(name);
-  });
+    return name !== null && matchesSuperpowersArtifactName(relativePath2, name);
+  }).sort(
+    (a, b) => (governingChangeName(b)?.length ?? 0) - (governingChangeName(a)?.length ?? 0)
+  )[0];
   if (named) return named;
   return eligible[0] ?? null;
 }
@@ -11332,7 +11354,9 @@ async function governingChange(relativePath2, projectRoot) {
     }
   }
   if (isSuperpowersArtifactPath(relativePath2)) {
-    return await superpowersArtifactGoverningChange(relativePath2, projectRoot) ?? repoSourceGoverningChange(projectRoot);
+    const superpowers = await superpowersArtifactGoverningChange(relativePath2, projectRoot);
+    if (superpowers) return superpowers;
+    return repoSourceGoverningChange(projectRoot);
   }
   return repoSourceGoverningChange(projectRoot);
 }
@@ -11450,7 +11474,7 @@ var classicHookGuardCommand = async (args) => {
   const phase = governing.phase;
   const openSpec = openSpecAllowed(relativePath2, phase);
   if (openSpec) return allowed(openSpec);
-  if (isSuperpowersArtifactPath(relativePath2) && (phase === "design" || phase === "build" || phase === "verify")) {
+  if (isSuperpowersArtifactPath(relativePath2) && allowsSuperpowersArtifacts(governing)) {
     return allowed(`${relativePath2} (phase: ${phase}, superpowers)`);
   }
   if (phase === "build" && governing.classic?.workflow === "full" && !governing.classic.designDoc) {

--- a/assets/skills/comet/scripts/comet-runtime.mjs
+++ b/assets/skills/comet/scripts/comet-runtime.mjs
@@ -11295,6 +11295,9 @@ var SUPERPOWERS_ARTIFACT_SUFFIXES = /* @__PURE__ */ new Set([
   "verification-report",
   "report"
 ]);
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
 function matchesRecordedSuperpowersArtifact(relativePath2, governing) {
   const artifactPaths = [
     governing.classic?.designDoc,
@@ -11309,13 +11312,9 @@ function matchesSuperpowersArtifactName(relativePath2, changeName) {
   const fileName = relativePath2.split("/").at(-1) ?? relativePath2;
   const stem = fileName.replace(/\.[^.]+$/u, "");
   if (stem === changeName) return true;
-  for (const separator of ["-", "_", "."]) {
-    const prefix = `${changeName}${separator}`;
-    if (!stem.startsWith(prefix)) continue;
-    const suffix = stem.slice(prefix.length);
-    if (SUPERPOWERS_ARTIFACT_SUFFIXES.has(suffix)) return true;
-  }
-  return false;
+  const suffixes = [...SUPERPOWERS_ARTIFACT_SUFFIXES].map(escapeRegex).join("|");
+  const pattern = new RegExp(`(^|[-_.])${escapeRegex(changeName)}[-_.](${suffixes})$`, "u");
+  return pattern.test(stem);
 }
 async function superpowersArtifactGoverningChange(relativePath2, projectRoot) {
   const active = await activeChanges(projectRoot);
@@ -11331,7 +11330,7 @@ async function superpowersArtifactGoverningChange(relativePath2, projectRoot) {
     (a, b) => (governingChangeName(b)?.length ?? 0) - (governingChangeName(a)?.length ?? 0)
   )[0];
   if (named) return named;
-  return eligible[0] ?? null;
+  return null;
 }
 async function repoSourceGoverningChange(projectRoot) {
   const active = await activeChanges(projectRoot);

--- a/domains/comet-classic/classic-hook-guard.ts
+++ b/domains/comet-classic/classic-hook-guard.ts
@@ -148,6 +148,54 @@ function blocksSourceWrites(governing: GoverningChange): boolean {
   );
 }
 
+function isSuperpowersArtifactPath(relativePath: string): boolean {
+  return relativePath.startsWith('docs/superpowers/');
+}
+
+function allowsSuperpowersArtifacts(governing: GoverningChange): boolean {
+  return (
+    governing.phase === 'design' || governing.phase === 'build' || governing.phase === 'verify'
+  );
+}
+
+function governingChangeName(governing: GoverningChange): string | null {
+  return governing.changeDir ? path.basename(governing.changeDir) : null;
+}
+
+function matchesRecordedSuperpowersArtifact(
+  relativePath: string,
+  governing: GoverningChange,
+): boolean {
+  const artifactPaths = [
+    governing.classic?.designDoc,
+    governing.classic?.plan,
+    governing.classic?.verificationReport,
+  ];
+  return artifactPaths.some(
+    (artifactPath) => artifactPath && normalized(artifactPath) === relativePath,
+  );
+}
+
+async function superpowersArtifactGoverningChange(
+  relativePath: string,
+  projectRoot: string,
+): Promise<GoverningChange | null> {
+  const active = await activeChanges(projectRoot);
+  const recorded = active.find((governing) =>
+    matchesRecordedSuperpowersArtifact(relativePath, governing),
+  );
+  if (recorded) return recorded;
+
+  const eligible = active.filter(allowsSuperpowersArtifacts);
+  const named = eligible.find((governing) => {
+    const name = governingChangeName(governing);
+    return name !== null && relativePath.includes(name);
+  });
+  if (named) return named;
+
+  return eligible[0] ?? null;
+}
+
 async function repoSourceGoverningChange(projectRoot: string): Promise<GoverningChange | null> {
   const active = await activeChanges(projectRoot);
   return active.find(blocksSourceWrites) ?? active[0] ?? null;
@@ -171,6 +219,12 @@ async function governingChange(
       }
       return { changeDir, phase: 'open', classic: null, archived: false };
     }
+  }
+  if (isSuperpowersArtifactPath(relativePath)) {
+    return (
+      (await superpowersArtifactGoverningChange(relativePath, projectRoot)) ??
+      repoSourceGoverningChange(projectRoot)
+    );
   }
   return repoSourceGoverningChange(projectRoot);
 }
@@ -321,7 +375,7 @@ export const classicHookGuardCommand: ClassicCommandHandler = async (args) => {
   const openSpec = openSpecAllowed(relativePath, phase);
   if (openSpec) return allowed(openSpec);
   if (
-    relativePath.startsWith('docs/superpowers/') &&
+    isSuperpowersArtifactPath(relativePath) &&
     (phase === 'design' || phase === 'build' || phase === 'verify')
   ) {
     return allowed(`${relativePath} (phase: ${phase}, superpowers)`);

--- a/domains/comet-classic/classic-hook-guard.ts
+++ b/domains/comet-classic/classic-hook-guard.ts
@@ -94,6 +94,7 @@ interface GoverningChange {
   phase: ClassicPhase;
   classic: ClassicState | null;
   archived: boolean;
+  superpowersArtifact?: 'matched' | 'unmatched';
 }
 
 async function loadGoverningChange(changeDir: string): Promise<GoverningChange | null> {
@@ -249,8 +250,9 @@ async function governingChange(
   }
   if (isSuperpowersArtifactPath(relativePath)) {
     const superpowers = await superpowersArtifactGoverningChange(relativePath, projectRoot);
-    if (superpowers) return superpowers;
-    return repoSourceGoverningChange(projectRoot);
+    if (superpowers) return { ...superpowers, superpowersArtifact: 'matched' };
+    const fallback = await repoSourceGoverningChange(projectRoot);
+    return fallback ? { ...fallback, superpowersArtifact: 'unmatched' } : null;
   }
   return repoSourceGoverningChange(projectRoot);
 }
@@ -361,6 +363,29 @@ function blockedMissingDesignDoc(relativePath: string): ClassicCommandResult {
   );
 }
 
+function blockedUnmatchedSuperpowersArtifact(
+  relativePath: string,
+  phase: ClassicPhase,
+): ClassicCommandResult {
+  return result(
+    2,
+    [
+      '',
+      '╔══════════════════════════════════════════╗',
+      '║     COMET PHASE GUARD — WRITE BLOCKED    ║',
+      '╚══════════════════════════════════════════╝',
+      '',
+      `  Current phase: ${phase}`,
+      `  Target file: ${relativePath}`,
+      '',
+      '  BLOCKED: unmatched Superpowers artifact',
+      '  This docs/superpowers/ path does not match any active change artifact',
+      '  NEXT: record the artifact path in .comet.yaml or include the change name in the artifact filename',
+      '',
+    ].join('\n'),
+  );
+}
+
 export const classicHookGuardCommand: ClassicCommandHandler = async (args) => {
   const projectRoot = parseProjectRoot(args);
   const target = inputTarget();
@@ -400,8 +425,13 @@ export const classicHookGuardCommand: ClassicCommandHandler = async (args) => {
 
   const openSpec = openSpecAllowed(relativePath, phase);
   if (openSpec) return allowed(openSpec);
-  if (isSuperpowersArtifactPath(relativePath) && allowsSuperpowersArtifacts(governing)) {
-    return allowed(`${relativePath} (phase: ${phase}, superpowers)`);
+  if (isSuperpowersArtifactPath(relativePath)) {
+    if (governing.superpowersArtifact === 'matched' && allowsSuperpowersArtifacts(governing)) {
+      return allowed(`${relativePath} (phase: ${phase}, superpowers)`);
+    }
+    if (governing.superpowersArtifact === 'unmatched') {
+      return blockedUnmatchedSuperpowersArtifact(relativePath, phase);
+    }
   }
   if (phase === 'build' && governing.classic?.workflow === 'full' && !governing.classic.designDoc) {
     return blockedMissingDesignDoc(relativePath);

--- a/domains/comet-classic/classic-hook-guard.ts
+++ b/domains/comet-classic/classic-hook-guard.ts
@@ -162,6 +162,15 @@ function governingChangeName(governing: GoverningChange): string | null {
   return governing.changeDir ? path.basename(governing.changeDir) : null;
 }
 
+const SUPERPOWERS_ARTIFACT_SUFFIXES = new Set([
+  'design',
+  'plan',
+  'verify',
+  'verification',
+  'verification-report',
+  'report',
+]);
+
 function matchesRecordedSuperpowersArtifact(
   relativePath: string,
   governing: GoverningChange,
@@ -176,6 +185,22 @@ function matchesRecordedSuperpowersArtifact(
   );
 }
 
+function matchesSuperpowersArtifactName(relativePath: string, changeName: string): boolean {
+  const fileName = relativePath.split('/').at(-1) ?? relativePath;
+  const stem = fileName.replace(/\.[^.]+$/u, '');
+  if (stem === changeName) return true;
+
+  for (const separator of ['-', '_', '.']) {
+    const prefix = `${changeName}${separator}`;
+    if (!stem.startsWith(prefix)) continue;
+
+    const suffix = stem.slice(prefix.length);
+    if (SUPERPOWERS_ARTIFACT_SUFFIXES.has(suffix)) return true;
+  }
+
+  return false;
+}
+
 async function superpowersArtifactGoverningChange(
   relativePath: string,
   projectRoot: string,
@@ -187,10 +212,14 @@ async function superpowersArtifactGoverningChange(
   if (recorded) return recorded;
 
   const eligible = active.filter(allowsSuperpowersArtifacts);
-  const named = eligible.find((governing) => {
-    const name = governingChangeName(governing);
-    return name !== null && relativePath.includes(name);
-  });
+  const named = eligible
+    .filter((governing) => {
+      const name = governingChangeName(governing);
+      return name !== null && matchesSuperpowersArtifactName(relativePath, name);
+    })
+    .sort(
+      (a, b) => (governingChangeName(b)?.length ?? 0) - (governingChangeName(a)?.length ?? 0),
+    )[0];
   if (named) return named;
 
   return eligible[0] ?? null;
@@ -221,10 +250,9 @@ async function governingChange(
     }
   }
   if (isSuperpowersArtifactPath(relativePath)) {
-    return (
-      (await superpowersArtifactGoverningChange(relativePath, projectRoot)) ??
-      repoSourceGoverningChange(projectRoot)
-    );
+    const superpowers = await superpowersArtifactGoverningChange(relativePath, projectRoot);
+    if (superpowers) return superpowers;
+    return repoSourceGoverningChange(projectRoot);
   }
   return repoSourceGoverningChange(projectRoot);
 }
@@ -374,10 +402,7 @@ export const classicHookGuardCommand: ClassicCommandHandler = async (args) => {
 
   const openSpec = openSpecAllowed(relativePath, phase);
   if (openSpec) return allowed(openSpec);
-  if (
-    isSuperpowersArtifactPath(relativePath) &&
-    (phase === 'design' || phase === 'build' || phase === 'verify')
-  ) {
+  if (isSuperpowersArtifactPath(relativePath) && allowsSuperpowersArtifacts(governing)) {
     return allowed(`${relativePath} (phase: ${phase}, superpowers)`);
   }
   if (phase === 'build' && governing.classic?.workflow === 'full' && !governing.classic.designDoc) {

--- a/domains/comet-classic/classic-hook-guard.ts
+++ b/domains/comet-classic/classic-hook-guard.ts
@@ -171,6 +171,10 @@ const SUPERPOWERS_ARTIFACT_SUFFIXES = new Set([
   'report',
 ]);
 
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+}
+
 function matchesRecordedSuperpowersArtifact(
   relativePath: string,
   governing: GoverningChange,
@@ -190,15 +194,9 @@ function matchesSuperpowersArtifactName(relativePath: string, changeName: string
   const stem = fileName.replace(/\.[^.]+$/u, '');
   if (stem === changeName) return true;
 
-  for (const separator of ['-', '_', '.']) {
-    const prefix = `${changeName}${separator}`;
-    if (!stem.startsWith(prefix)) continue;
-
-    const suffix = stem.slice(prefix.length);
-    if (SUPERPOWERS_ARTIFACT_SUFFIXES.has(suffix)) return true;
-  }
-
-  return false;
+  const suffixes = [...SUPERPOWERS_ARTIFACT_SUFFIXES].map(escapeRegex).join('|');
+  const pattern = new RegExp(`(^|[-_.])${escapeRegex(changeName)}[-_.](${suffixes})$`, 'u');
+  return pattern.test(stem);
 }
 
 async function superpowersArtifactGoverningChange(
@@ -222,7 +220,7 @@ async function superpowersArtifactGoverningChange(
     )[0];
   if (named) return named;
 
-  return eligible[0] ?? null;
+  return null;
 }
 
 async function repoSourceGoverningChange(projectRoot: string): Promise<GoverningChange | null> {

--- a/domains/skill/platform-install.ts
+++ b/domains/skill/platform-install.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { existsSync } from 'fs';
-import { readFile, writeFile, lstat, unlink, symlink, rm } from 'fs/promises';
+import { readFile, writeFile, lstat, unlink, symlink, rm, readdir } from 'fs/promises';
 import { fileURLToPath } from 'url';
 import { parseDocument } from 'yaml';
 
@@ -59,6 +59,51 @@ function getUserFacingSkillNames(manifest: Manifest): string[] {
   return getTopLevelSkillNames(manifest.skills);
 }
 
+function getManagedSkillReplacementPaths(manifest: Manifest): Set<string> {
+  const allowed = new Set<string>();
+
+  for (const skillPath of getManagedSkillPaths(manifest)) {
+    const parts = skillPath.split('/').filter(Boolean);
+    for (let depth = 1; depth <= parts.length; depth++) {
+      allowed.add(parts.slice(0, depth).join('/'));
+    }
+  }
+
+  return allowed;
+}
+
+async function collectDirectoryEntryPaths(root: string, current = root): Promise<string[]> {
+  const entries = await readdir(current, { withFileTypes: true });
+  const paths: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(current, entry.name);
+    const relativePath = path.relative(root, fullPath).split(path.sep).join('/');
+    paths.push(relativePath);
+
+    if (entry.isDirectory() && !entry.isSymbolicLink()) {
+      paths.push(...(await collectDirectoryEntryPaths(root, fullPath)));
+    }
+  }
+
+  return paths;
+}
+
+async function assertDirectoryContainsOnlyManagedEntries(
+  dirPath: string,
+  managedEntries: Set<string>,
+): Promise<void> {
+  const entries = await collectDirectoryEntryPaths(dirPath);
+  const unmanagedEntries = entries.filter((entry) => !managedEntries.has(entry));
+  if (unmanagedEntries.length === 0) return;
+
+  const preview = unmanagedEntries.slice(0, 5).join(', ');
+  const suffix = unmanagedEntries.length > 5 ? `, and ${unmanagedEntries.length - 5} more` : '';
+  throw new Error(
+    `Refusing to replace ${dirPath} with a symlink because it contains unmanaged entries: ${preview}${suffix}. Move them aside or use copy install mode.`,
+  );
+}
+
 const OPENCODE_COMMAND_HEADER = `---
 description: Run the {skillName} Comet workflow
 ---
@@ -94,24 +139,33 @@ function getCentralSkillsDir(baseDir: string, _scope: InstallScope): string {
  * Create a symlink from linkPath pointing to target.
  * On Windows, uses 'junction' type for directory symlinks (no admin required).
  */
-async function createSymlink(target: string, linkPath: string): Promise<void> {
+async function createSymlink(
+  target: string,
+  linkPath: string,
+  managedEntries: Set<string>,
+): Promise<void> {
   await ensureDir(path.dirname(linkPath));
 
   // Remove existing link/directory if present
+  let stat: Awaited<ReturnType<typeof lstat>> | null = null;
   try {
-    const stat = await lstat(linkPath);
-    if (stat.isSymbolicLink()) {
-      await unlink(linkPath);
-    } else if (stat.isDirectory()) {
-      // For directories, try unlink first (handles Windows junctions)
-      try {
-        await unlink(linkPath);
-      } catch {
-        await rm(linkPath, { recursive: true, force: true });
-      }
+    stat = await lstat(linkPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw err;
     }
-  } catch {
-    // Path doesn't exist, continue
+  }
+
+  if (stat?.isSymbolicLink()) {
+    await unlink(linkPath);
+  } else if (stat?.isDirectory()) {
+    // For directories, try unlink first (handles Windows junctions)
+    try {
+      await unlink(linkPath);
+    } catch {
+      await assertDirectoryContainsOnlyManagedEntries(linkPath, managedEntries);
+      await rm(linkPath, { recursive: true, force: true });
+    }
   }
 
   // Windows uses 'junction' for directory symlinks (no admin privileges required)
@@ -143,6 +197,7 @@ async function installSkillsAsSymlink(
   if (!manifest || !Array.isArray(manifest.skills)) {
     throw new Error(`Invalid manifest at ${manifestPath}: "skills" must be an array`);
   }
+  const managedSkillReplacementPaths = getManagedSkillReplacementPaths(manifest);
 
   // Step 1: Copy skills to central store
   let copied = 0;
@@ -176,7 +231,7 @@ async function installSkillsAsSymlink(
   const centralSkillsDir = path.join(centralDir, 'skills');
 
   try {
-    await createSymlink(centralSkillsDir, platformSkillsDir);
+    await createSymlink(centralSkillsDir, platformSkillsDir, managedSkillReplacementPaths);
   } catch (err) {
     failedCount++;
     console.error(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rpamis/comet",
-  "version": "0.4.0-beta.1",
+  "version": "0.4.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rpamis/comet",
-      "version": "0.4.0-beta.1",
+      "version": "0.4.0-beta.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rpamis/comet",
-  "version": "0.4.0-beta.1",
+  "version": "0.4.0-beta.2",
   "description": "Agent Skill Harness Phase-Guarded Automation From Idea To Archive",
   "keywords": [
     "comet",

--- a/test/domains/comet-classic/comet-scripts.test.ts
+++ b/test/domains/comet-classic/comet-scripts.test.ts
@@ -4984,6 +4984,28 @@ describe('comet scripts', () => {
       expect(result.status).toBe(0);
     }, 20_000);
 
+    it('allows docs/superpowers writes for the matching design change when another active change is open', async () => {
+      await createChange(
+        tmpDir,
+        'cert-signature-auth',
+        ['workflow: full', 'phase: open', 'archived: false', ''].join('\n'),
+      );
+      await createChange(
+        tmpDir,
+        'env-issue-ledger',
+        ['workflow: full', 'phase: design', 'archived: false', ''].join('\n'),
+      );
+
+      const docsDir = path.join(tmpDir, 'docs', 'superpowers', 'specs');
+      await fs.mkdir(docsDir, { recursive: true });
+      const targetFile = path.join(docsDir, 'env-issue-ledger-design.md');
+
+      const result = runHookGuard(tmpDir, hookGuardScript, hookStdin(targetFile));
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toContain('phase: design, superpowers');
+    }, 20_000);
+
     it('blocks repo source writes when any active change is still in design', async () => {
       await createChange(
         tmpDir,

--- a/test/domains/comet-classic/comet-scripts.test.ts
+++ b/test/domains/comet-classic/comet-scripts.test.ts
@@ -4628,7 +4628,7 @@ describe('comet scripts', () => {
       expect(result.status).toBe(0);
     }, 20_000);
 
-    it('allows writes to docs/superpowers/ in design phase', async () => {
+    it('allows matching docs/superpowers/ writes in design phase', async () => {
       await createChange(
         tmpDir,
         'test-hook',
@@ -4659,7 +4659,7 @@ describe('comet scripts', () => {
 
       const docsDir = path.join(tmpDir, 'docs', 'superpowers', 'specs');
       await fs.mkdir(docsDir, { recursive: true });
-      const targetFile = path.join(docsDir, '2026-06-06-test-design.md');
+      const targetFile = path.join(docsDir, '2026-06-06-test-hook-design.md');
 
       const result = runHookGuard(tmpDir, hookGuardScript, hookStdin(targetFile));
 
@@ -5048,6 +5048,34 @@ describe('comet scripts', () => {
 
       expect(result.status).toBe(2);
       expect(result.stderr).toContain('Current phase: open');
+    }, 20_000);
+
+    it('blocks unmatched docs/superpowers writes when all active changes are eligible phases', async () => {
+      await createChange(
+        tmpDir,
+        'auth',
+        ['workflow: full', 'phase: design', 'archived: false', ''].join('\n'),
+      );
+      await createChange(
+        tmpDir,
+        'payments',
+        [
+          'workflow: full',
+          'phase: build',
+          'design_doc: docs/superpowers/specs/payments-design.md',
+          'archived: false',
+          '',
+        ].join('\n'),
+      );
+
+      const docsDir = path.join(tmpDir, 'docs', 'superpowers', 'specs');
+      await fs.mkdir(docsDir, { recursive: true });
+      const targetFile = path.join(docsDir, '2026-06-06-legacy-design.md');
+
+      const result = runHookGuard(tmpDir, hookGuardScript, hookStdin(targetFile));
+
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('unmatched Superpowers artifact');
     }, 20_000);
 
     it('blocks repo source writes when any active change is still in design', async () => {

--- a/test/domains/comet-classic/comet-scripts.test.ts
+++ b/test/domains/comet-classic/comet-scripts.test.ts
@@ -5006,6 +5006,28 @@ describe('comet scripts', () => {
       expect(result.stderr).toContain('phase: design, superpowers');
     }, 20_000);
 
+    it('matches docs/superpowers writes to the longest change name boundary', async () => {
+      await createChange(
+        tmpDir,
+        'auth',
+        ['workflow: full', 'phase: verify', 'archived: false', ''].join('\n'),
+      );
+      await createChange(
+        tmpDir,
+        'auth-v2',
+        ['workflow: full', 'phase: design', 'archived: false', ''].join('\n'),
+      );
+
+      const docsDir = path.join(tmpDir, 'docs', 'superpowers', 'specs');
+      await fs.mkdir(docsDir, { recursive: true });
+      const targetFile = path.join(docsDir, 'auth-v2-design.md');
+
+      const result = runHookGuard(tmpDir, hookGuardScript, hookStdin(targetFile));
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toContain('phase: design, superpowers');
+    }, 20_000);
+
     it('blocks repo source writes when any active change is still in design', async () => {
       await createChange(
         tmpDir,

--- a/test/domains/comet-classic/comet-scripts.test.ts
+++ b/test/domains/comet-classic/comet-scripts.test.ts
@@ -5020,12 +5020,34 @@ describe('comet scripts', () => {
 
       const docsDir = path.join(tmpDir, 'docs', 'superpowers', 'specs');
       await fs.mkdir(docsDir, { recursive: true });
-      const targetFile = path.join(docsDir, 'auth-v2-design.md');
+      const targetFile = path.join(docsDir, '2026-06-06-auth-v2-design.md');
 
       const result = runHookGuard(tmpDir, hookGuardScript, hookStdin(targetFile));
 
       expect(result.status).toBe(0);
       expect(result.stderr).toContain('phase: design, superpowers');
+    }, 20_000);
+
+    it('does not route unmatched docs/superpowers writes to an unrelated eligible change', async () => {
+      await createChange(
+        tmpDir,
+        'a-open-change',
+        ['workflow: full', 'phase: open', 'archived: false', ''].join('\n'),
+      );
+      await createChange(
+        tmpDir,
+        'z-design-change',
+        ['workflow: full', 'phase: design', 'archived: false', ''].join('\n'),
+      );
+
+      const docsDir = path.join(tmpDir, 'docs', 'superpowers', 'specs');
+      await fs.mkdir(docsDir, { recursive: true });
+      const targetFile = path.join(docsDir, '2026-06-06-a-open-change-design.md');
+
+      const result = runHookGuard(tmpDir, hookGuardScript, hookStdin(targetFile));
+
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('Current phase: open');
     }, 20_000);
 
     it('blocks repo source writes when any active change is still in design', async () => {

--- a/test/domains/skill/symlink-install.test.ts
+++ b/test/domains/skill/symlink-install.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import path from 'path';
-import { mkdtemp, rm, lstat, realpath } from 'fs/promises';
+import { mkdir, mkdtemp, rm, lstat, readFile, realpath, writeFile } from 'fs/promises';
 import os from 'os';
 import {
   copyCometSkillsForPlatform,
@@ -106,6 +106,32 @@ describe('symlink install mode', () => {
       );
 
       expect(result.copied).toBeGreaterThan(0);
+    });
+
+    it('does not replace an existing skills directory that contains unmanaged files', async () => {
+      const existingSkill = path.join(tmpDir, '.claude', 'skills', 'personal-skill', 'SKILL.md');
+      const existingNestedFile = path.join(tmpDir, '.claude', 'skills', 'comet', 'local-notes.md');
+      await mkdir(path.dirname(existingSkill), { recursive: true });
+      await mkdir(path.dirname(existingNestedFile), { recursive: true });
+      await writeFile(existingSkill, '# Personal Skill\n', 'utf-8');
+      await writeFile(existingNestedFile, '# Local notes\n', 'utf-8');
+
+      const result = await copyCometSkillsForPlatform(
+        tmpDir,
+        mockPlatform,
+        true,
+        'skills',
+        'project',
+        'symlink',
+      );
+
+      expect(result.failed).toBe(1);
+      expect(await readFile(existingSkill, 'utf-8')).toBe('# Personal Skill\n');
+      expect(await readFile(existingNestedFile, 'utf-8')).toBe('# Local notes\n');
+
+      const platformSkillsDir = path.join(tmpDir, '.claude', 'skills');
+      const stat = await lstat(platformSkillsDir);
+      expect(stat.isSymbolicLink()).toBe(false);
     });
 
     it('uses copy behavior when mode is copy (default)', async () => {


### PR DESCRIPTION
## Summary
- Prevent symlink-mode installs from replacing an existing platform `skills/` directory when it contains unmanaged files, preserving local or third-party Skills (#159).
- Route Classic `docs/superpowers/` writes to the matching design/build/verify change so an unrelated active change no longer blocks shared Superpowers artifacts (#160).
- Bump the package to `0.4.0-beta.2` and sync the website changelog/version entries through the `website` submodule pointer.

## Tests
- `npx vitest run test/domains/comet-classic/comet-scripts.test.ts test/domains/comet-classic/classic-hook-guard.test.ts test/domains/skill/symlink-install.test.ts test/domains/skill/skills.test.ts`
- `git diff --check`
- `git -C website diff --check`

## Summary by Sourcery

Protect symlink-based skill installs and adjust Classic superpowers artifact routing while preparing the 0.4.0-beta.2 release.

Bug Fixes:
- Prevent symlink-mode installs from replacing an existing platform skills directory when it contains unmanaged files, preserving local or third-party content.
- Route docs/superpowers writes to the appropriate design/build/verify governing change instead of being blocked by an unrelated active change.

Enhancements:
- Add test coverage for symlink install safety and superpowers artifact routing behavior.

Build:
- Bump package version to 0.4.0-beta.2 and update the changelog and website submodule accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of `docs/superpowers` writes so the correct active change is used, and unmatched files are now blocked more clearly.
  * Fixed phase-guard installs to include only the language-specific rule file needed for the selected setup.
  * Prevented symlink-based installs from replacing existing skill folders when they contain files that aren’t managed.

* **Tests**
  * Added coverage for Superpowers write routing and symlink-install protection behavior.

* **Documentation**
  * Updated the changelog with the latest beta release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->