### PR TITLE
fix: improve doctor scope diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to @rpamis/comet will be documented in this file.
 
 ### Fixed
 
+- **Doctor scope diagnostics**: `comet doctor` now reports auto-scope behavior, Node/platform environment details, and a non-alarming project-scope note when a global Comet install is available but the current project has no local Skill copy, so users can distinguish an optional project install from a broken setup.
 - **Single-language rule install**: `comet init` and `comet update` now install only the Comet phase-guard rule file matching the selected/detected Skill language (e.g. `.claude/rules/comet-phase-guard.md`), instead of always installing both the Chinese and English rule variants side by side regardless of language choice.
 - **Symlink install safety**: `comet init` and `comet update` now refuse to replace an existing platform `skills/` directory with a symlink when it contains files outside Comet's managed manifest, preserving local or third-party Skills instead of deleting them during symlink-mode installs ([#159](https://github.com/rpamis/comet/issues/159)).
 - **Parallel change artifact writes**: Classic phase guards now route `docs/superpowers/` writes to the matching design/build/verify change instead of letting an unrelated earlier active change block shared Design Doc and planning artifacts ([#160](https://github.com/rpamis/comet/issues/160)).

--- a/app/commands/doctor.ts
+++ b/app/commands/doctor.ts
@@ -24,6 +24,9 @@ interface CheckResult {
 }
 
 type DoctorScope = InstallScope | 'auto';
+interface DoctorContext {
+  homeDir: string;
+}
 
 const SUPERPOWERS_SENTINELS = [
   'using-superpowers/SKILL.md',
@@ -57,6 +60,30 @@ async function checkOpenSpecCli(): Promise<CheckResult> {
   }
 }
 
+function checkEnvironment(projectPath: string, context: DoctorContext): CheckResult {
+  return {
+    check: 'Environment',
+    status: 'pass',
+    message: `node ${process.version}; platform ${process.platform}/${process.arch}; project ${projectPath}; global ${context.homeDir}`,
+  };
+}
+
+function checkScopeMode(
+  projectPath: string,
+  scope: DoctorScope,
+  context: DoctorContext,
+): CheckResult | null {
+  if (scope !== 'auto') return null;
+  const includesGlobal = path.resolve(projectPath) !== path.resolve(context.homeDir);
+  return {
+    check: 'Scope',
+    status: 'pass',
+    message: includesGlobal
+      ? 'auto checks project scope first, then global scope when it is different'
+      : 'auto checks project scope only because project path is the global home directory',
+  };
+}
+
 async function checkWorkingDirs(projectPath: string): Promise<CheckResult> {
   const specsDir = path.join(projectPath, 'docs', 'superpowers', 'specs');
   const plansDir = path.join(projectPath, 'docs', 'superpowers', 'plans');
@@ -67,7 +94,12 @@ async function checkWorkingDirs(projectPath: string): Promise<CheckResult> {
     return { check: 'working directories', status: 'pass', message: 'present' };
   }
   if (!specsExist && !plansExist) {
-    return { check: 'working directories', status: 'fail', message: 'missing — run: comet init' };
+    return {
+      check: 'working directories',
+      status: 'warn',
+      message:
+        'project not initialized for Comet — run: comet init --scope project if this project should use Comet workflows',
+    };
   }
   const missing = [];
   if (!specsExist) missing.push('specs');
@@ -79,9 +111,13 @@ async function checkWorkingDirs(projectPath: string): Promise<CheckResult> {
   };
 }
 
-async function checkSuperpowers(projectPath: string, scope: DoctorScope): Promise<CheckResult> {
+async function checkSuperpowers(
+  projectPath: string,
+  scope: DoctorScope,
+  context: DoctorContext,
+): Promise<CheckResult> {
   const detected: string[] = [];
-  for (const base of getScopeBases(projectPath, scope)) {
+  for (const base of getScopeBases(projectPath, scope, context)) {
     for (const platform of PLATFORMS) {
       for (const skillsDir of getPlatformSkillsDirs(platform, base.scope)) {
         for (const sentinel of SUPERPOWERS_SENTINELS) {
@@ -113,18 +149,19 @@ async function checkSuperpowers(projectPath: string, scope: DoctorScope): Promis
 function getScopeBases(
   projectPath: string,
   scope: DoctorScope,
+  context: DoctorContext,
 ): Array<{
   scope: InstallScope;
   baseDir: string;
 }> {
   if (scope === 'project') return [{ scope, baseDir: projectPath }];
-  if (scope === 'global') return [{ scope, baseDir: os.homedir() }];
+  if (scope === 'global') return [{ scope, baseDir: context.homeDir }];
 
   const bases: Array<{ scope: InstallScope; baseDir: string }> = [
     { scope: 'project', baseDir: projectPath },
   ];
-  if (path.resolve(projectPath) !== path.resolve(os.homedir())) {
-    bases.push({ scope: 'global', baseDir: os.homedir() });
+  if (path.resolve(projectPath) !== path.resolve(context.homeDir)) {
+    bases.push({ scope: 'global', baseDir: context.homeDir });
   }
   return bases;
 }
@@ -132,6 +169,7 @@ function getScopeBases(
 async function checkSkillCompleteness(
   projectPath: string,
   scope: DoctorScope,
+  context: DoctorContext,
 ): Promise<CheckResult[]> {
   const results: CheckResult[] = [];
   const manifest = await readManifest();
@@ -139,7 +177,11 @@ async function checkSkillCompleteness(
   const total = managedSkills.length;
 
   let anyCometInstall = false;
-  for (const base of getScopeBases(projectPath, scope)) {
+  const scopeState: Record<InstallScope, { hasInstall: boolean; hasComplete: boolean }> = {
+    project: { hasInstall: false, hasComplete: false },
+    global: { hasInstall: false, hasComplete: false },
+  };
+  for (const base of getScopeBases(projectPath, scope, context)) {
     for (const platform of PLATFORMS) {
       const detectedSkillsDir = (
         await Promise.all(
@@ -164,6 +206,10 @@ async function checkSkillCompleteness(
 
       if (present.length === 0) continue;
       anyCometInstall = true;
+      scopeState[base.scope].hasInstall = true;
+      if (missing.length === 0) {
+        scopeState[base.scope].hasComplete = true;
+      }
 
       results.push(
         missing.length === 0
@@ -179,6 +225,15 @@ async function checkSkillCompleteness(
             },
       );
     }
+  }
+
+  if (scope === 'auto' && !scopeState.project.hasInstall && scopeState.global.hasComplete) {
+    results.push({
+      check: 'Project scope',
+      status: 'pass',
+      message:
+        'no project-local Comet skills installed; global scope is available — run: comet init --scope project only if this project needs its own copy',
+    });
   }
 
   if (!anyCometInstall) {
@@ -305,14 +360,26 @@ async function checkCodegraph(projectPath: string, scope: DoctorScope): Promise<
 }
 
 async function collectResults(projectPath: string, scope: DoctorScope): Promise<CheckResult[]> {
+  const context = { homeDir: os.homedir() };
+  return collectResultsWithContext(projectPath, scope, context);
+}
+
+async function collectResultsWithContext(
+  projectPath: string,
+  scope: DoctorScope,
+  context: DoctorContext,
+): Promise<CheckResult[]> {
   const results: CheckResult[] = [];
+  const scopeMode = checkScopeMode(projectPath, scope, context);
+  if (scopeMode) results.push(scopeMode);
+  results.push(checkEnvironment(projectPath, context));
   results.push(checkCometCli());
   results.push(await checkOpenSpecCli());
-  results.push(await checkSuperpowers(projectPath, scope));
+  results.push(await checkSuperpowers(projectPath, scope, context));
   if (scope !== 'global') {
     results.push(await checkWorkingDirs(projectPath));
   }
-  results.push(...(await checkSkillCompleteness(projectPath, scope)));
+  results.push(...(await checkSkillCompleteness(projectPath, scope, context)));
   results.push(await checkScriptsPresent());
   results.push(await checkCodegraph(projectPath, scope));
   results.push(...(await checkCometYamlValidity(projectPath)));
@@ -328,6 +395,7 @@ function icon(status: string): string {
 interface DoctorOptions {
   json?: boolean;
   scope?: DoctorScope;
+  homeDir?: string;
 }
 
 export async function doctorCommand(
@@ -336,7 +404,12 @@ export async function doctorCommand(
 ): Promise<void> {
   const projectPath = path.resolve(targetPath);
   const scope = options.scope ?? 'auto';
-  const results = await collectResults(projectPath, scope);
+  const results =
+    options.homeDir === undefined
+      ? await collectResults(projectPath, scope)
+      : await collectResultsWithContext(projectPath, scope, {
+          homeDir: path.resolve(options.homeDir),
+        });
 
   if (options.json) {
     console.log(JSON.stringify({ scope, results }, null, 2));

--- a/test/app/doctor.test.ts
+++ b/test/app/doctor.test.ts
@@ -7,6 +7,21 @@ import { doctorCommand } from '../../app/commands/doctor.js';
 
 const stateScript = path.resolve('assets', 'skills', 'comet', 'scripts', 'comet-state.mjs');
 
+async function installManagedCometSkills(baseDir: string): Promise<void> {
+  const manifest = JSON.parse(
+    await fs.readFile(path.resolve('assets', 'manifest.json'), 'utf8'),
+  ) as {
+    skills: string[];
+    internalSkills?: string[];
+  };
+  const managedPaths = [...new Set([...manifest.skills, ...(manifest.internalSkills ?? [])])];
+  for (const relPath of managedPaths) {
+    const target = path.join(baseDir, '.claude', 'skills', ...relPath.split('/'));
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await fs.writeFile(target, `${relPath}\n`);
+  }
+}
+
 function state(cwd: string, ...args: string[]) {
   const env: NodeJS.ProcessEnv = { ...process.env };
   if (args[0] === 'set' && args[2] === 'phase') {
@@ -70,6 +85,32 @@ describe('doctor command', () => {
     }
 
     expect(output).toContain('Comet CLI: installed (');
+  });
+
+  it('explains auto scope and treats global installs as available when project scope is empty', async () => {
+    const fakeHome = path.join(tmpDir, 'home');
+    await installManagedCometSkills(fakeHome);
+
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    let output = '';
+    try {
+      await doctorCommand(tmpDir, { homeDir: fakeHome });
+      output = log.mock.calls.map((call) => call.join(' ')).join('\n');
+    } finally {
+      log.mockRestore();
+    }
+
+    expect(output).toContain(
+      'Scope: auto checks project scope first, then global scope when it is different',
+    );
+    expect(output).toContain('skills: Claude Code (global): complete');
+    expect(output).toContain(
+      'Project scope: no project-local Comet skills installed; global scope is available',
+    );
+    expect(output).toContain(
+      'run: comet init --scope project only if this project needs its own copy',
+    );
+    expect(output).not.toContain('skills: Claude Code (project): missing');
   });
 
   it('does not report non-Comet skill directories as missing Comet installs in auto scope', async () => {
@@ -159,7 +200,9 @@ describe('doctor command', () => {
       log.mockRestore();
     }
     const payload = JSON.parse(json);
-    const cometYaml = payload.results.find((item: { check: string }) => item.check === '.comet.yaml: demo');
+    const cometYaml = payload.results.find(
+      (item: { check: string }) => item.check === '.comet.yaml: demo',
+    );
 
     expect(cometYaml.message).toContain('step: full.open');
     expect(cometYaml.message).toContain('mode: engine-projection');
@@ -202,8 +245,6 @@ describe('doctor command', () => {
     expect(output).toContain(
       '.comet.yaml: top-level-invalid: Invalid Classic state: unknown field(s): unknown_root_field',
     );
-    expect(output).toContain(
-      'next: top-level-invalid: inspect .comet.yaml and rerun comet doctor',
-    );
+    expect(output).toContain('next: top-level-invalid: inspect .comet.yaml and rerun comet doctor');
   });
 });


### PR DESCRIPTION
## Summary
- Add explicit `comet doctor` auto-scope and environment diagnostics.
- Clarify when project-local Comet skills are optional because a global install is available.
- Add regression coverage for global-only install diagnostics and update changelog.

## Test Plan
- pnpm exec vitest run test/app/doctor.test.ts
- pnpm format:check
- pnpm lint
- pnpm build
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false pnpm test

## Summary by Sourcery

Improve `comet doctor` diagnostics for auto scope behavior and environment reporting, and add regression coverage for global-only installs.

New Features:
- Add environment details and auto scope mode explanation to `comet doctor` output.
- Report when a global Comet install is available so project-local skills are optional, instead of treating this as a broken setup.

Enhancements:
- Refine working directory checks to emit a warning with clearer guidance when a project is not initialized for Comet.
- Adjust scope resolution logic to consistently use an injectable home directory for global installs.

Documentation:
- Document the improved doctor scope diagnostics in the changelog.

Tests:
- Add regression tests covering auto scope diagnostics and behavior when only a global Comet install is present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `comet doctor` now gives clearer guidance about scope and environment details, including when it’s using auto scope.
  * It better distinguishes a missing local project setup from a broken installation, reducing false alarms.
  * When no project files are present, the message now suggests the more specific `comet init --scope project` command.
  * Auto-scope checks now report whether global or project-level skills are available, making setup issues easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->