### PR TITLE
fix: Windows file identity handling and security vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to @rpamis/comet will be documented in this file.
 
 - **Windows Native file validation**: Native commands now accept stable files when Windows path and handle metadata expose different availability for device or inode identifiers, preventing `comet status`, `comet doctor`, and other Native reads from incorrectly failing with `changed while opening` while preserving replacement and mutation checks.
 
+### Security
+
+- **Development dependency hardening**: Pins `brace-expansion` to the patched 5.0.7 release across npm and pnpm resolution, preventing malicious brace patterns from causing exponential CPU consumption in the development toolchain.
+
 ## What's Changed [0.4.0-beta.7] - 2026-07-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to @rpamis/comet will be documented in this file.
 ### Security
 
 - **Development dependency hardening**: Pins `brace-expansion` to the patched 5.0.7 release across npm and pnpm resolution, preventing malicious brace patterns from causing exponential CPU consumption in the development toolchain.
+- **Classic handoff validation**: Validates recorded handoff source paths with exact line matching instead of project-controlled regular expressions, preventing malformed spec directory names from crashing or stalling the Classic design guard.
 
 ## What's Changed [0.4.0-beta.7] - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to @rpamis/comet will be documented in this file.
 
+## What's Changed [0.4.0-beta.8] - 2026-07-22
+
+### Fixed
+
+- **Windows Native file validation**: Native commands now accept stable files when Windows path and handle metadata expose different availability for device or inode identifiers, preventing `comet status`, `comet doctor`, and other Native reads from incorrectly failing with `changed while opening` while preserving replacement and mutation checks.
+
 ## What's Changed [0.4.0-beta.7] - 2026-07-20
 
 ### Added

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0-beta.7",
+  "version": "0.4.0-beta.8",
   "skills": [
     "comet/SKILL.md",
     "comet-classic/SKILL.md",

--- a/assets/skills/comet-native/scripts/comet-native-runtime.mjs
+++ b/assets/skills/comet-native/scripts/comet-native-runtime.mjs
@@ -7586,6 +7586,22 @@ function nativeSensitiveArtifactReason(paths, relativeRef) {
   return null;
 }
 
+// domains/comet-native/native-file-identity.ts
+function hasPlatformIdentity(value) {
+  return value !== 0 && value !== 0n && value !== "0";
+}
+function hasComparableNativeFileObject(left, right) {
+  return hasPlatformIdentity(left.dev) && hasPlatformIdentity(right.dev) && hasPlatformIdentity(left.ino) && hasPlatformIdentity(right.ino);
+}
+function sameNativeFileObject(left, right) {
+  const comparableDevice = hasPlatformIdentity(left.dev) && hasPlatformIdentity(right.dev);
+  if (comparableDevice && left.dev !== right.dev) return false;
+  const comparableInode = hasPlatformIdentity(left.ino) && hasPlatformIdentity(right.ino);
+  if (comparableInode && left.ino !== right.ino) return false;
+  if (comparableDevice && comparableInode) return true;
+  return left.birthtime === right.birthtime;
+}
+
 // domains/comet-native/native-bounded-file.ts
 var DEFAULT_NATIVE_ARTIFACT_MAX_BYTES = 1024 * 1024;
 function isInside(parent, target) {
@@ -7616,16 +7632,21 @@ function positiveLimit(value) {
   return value;
 }
 function sameDirectoryIdentity(identity, stat) {
-  if (identity.dev !== 0 || identity.ino !== 0 || stat.dev !== 0 || stat.ino !== 0) {
-    return identity.dev === stat.dev && identity.ino === stat.ino;
-  }
-  return identity.birthtimeMs === stat.birthtimeMs;
+  return sameNativeFileObject(
+    { ...identity, birthtime: identity.birthtimeMs },
+    {
+      ...stat,
+      birthtime: stat.birthtimeMs
+    }
+  );
 }
 function sameFileIdentity(left, right) {
-  if (left.dev !== 0 || left.ino !== 0 || right.dev !== 0 || right.ino !== 0) {
-    return left.dev === right.dev && left.ino === right.ino;
+  const leftObject = { ...left, birthtime: left.birthtimeMs };
+  const rightObject = { ...right, birthtime: right.birthtimeMs };
+  if (hasComparableNativeFileObject(leftObject, rightObject)) {
+    return sameNativeFileObject(leftObject, rightObject);
   }
-  return left.birthtimeMs === right.birthtimeMs && left.ctimeMs === right.ctimeMs && left.size === right.size;
+  return sameNativeFileObject(leftObject, rightObject) && left.birthtimeMs === right.birthtimeMs && left.ctimeMs === right.ctimeMs && left.size === right.size;
 }
 async function directoryIdentity(directory) {
   const stat = await fs.lstat(directory);
@@ -7741,16 +7762,21 @@ function isInside2(parent, target) {
   return relative === "" || !path3.isAbsolute(relative) && relative !== ".." && !relative.startsWith(`..${path3.sep}`);
 }
 function sameDirectoryIdentity2(identity, stat) {
-  if (identity.dev !== 0 || identity.ino !== 0 || stat.dev !== 0 || stat.ino !== 0) {
-    return identity.dev === stat.dev && identity.ino === stat.ino;
-  }
-  return identity.birthtimeMs === stat.birthtimeMs;
+  return sameNativeFileObject(
+    { ...identity, birthtime: identity.birthtimeMs },
+    {
+      ...stat,
+      birthtime: stat.birthtimeMs
+    }
+  );
 }
 function sameFileIdentity2(left, right) {
-  if (left.dev !== 0 || left.ino !== 0 || right.dev !== 0 || right.ino !== 0) {
-    return left.dev === right.dev && left.ino === right.ino;
+  const leftObject = { ...left, birthtime: left.birthtimeMs };
+  const rightObject = { ...right, birthtime: right.birthtimeMs };
+  if (hasComparableNativeFileObject(leftObject, rightObject)) {
+    return sameNativeFileObject(leftObject, rightObject);
   }
-  return left.birthtimeMs === right.birthtimeMs && left.ctimeMs === right.ctimeMs && left.size === right.size;
+  return sameNativeFileObject(leftObject, rightObject) && left.birthtimeMs === right.birthtimeMs && left.ctimeMs === right.ctimeMs && left.size === right.size;
 }
 async function captureDirectoryIdentity(directory) {
   const stat = await fs2.lstat(directory);
@@ -7973,10 +7999,13 @@ function positiveLimit2(value) {
   return value;
 }
 function sameDirectoryIdentity3(expected, actual) {
-  if (expected.dev !== 0 || expected.ino !== 0 || actual.dev !== 0 || actual.ino !== 0) {
-    return expected.dev === actual.dev && expected.ino === actual.ino;
-  }
-  return expected.birthtimeMs === actual.birthtimeMs;
+  return sameNativeFileObject(
+    { ...expected, birthtime: expected.birthtimeMs },
+    {
+      ...actual,
+      birthtime: actual.birthtimeMs
+    }
+  );
 }
 function asFileIdentity(stat) {
   return {
@@ -7989,8 +8018,13 @@ function asFileIdentity(stat) {
   };
 }
 function sameFileIdentity3(expected, actual) {
-  const sameObject = expected.dev !== 0 || expected.ino !== 0 || actual.dev !== 0 || actual.ino !== 0 ? expected.dev === actual.dev && expected.ino === actual.ino : expected.birthtimeMs === actual.birthtimeMs;
-  return sameObject && expected.birthtimeMs === actual.birthtimeMs && expected.ctimeMs === actual.ctimeMs && expected.mtimeMs === actual.mtimeMs && expected.size === actual.size;
+  return sameNativeFileObject(
+    { ...expected, birthtime: expected.birthtimeMs },
+    {
+      ...actual,
+      birthtime: actual.birthtimeMs
+    }
+  ) && expected.birthtimeMs === actual.birthtimeMs && expected.ctimeMs === actual.ctimeMs && expected.mtimeMs === actual.mtimeMs && expected.size === actual.size;
 }
 async function captureDirectoryIdentity2(directory, label) {
   const stat = await fs3.lstat(directory);
@@ -8830,10 +8864,12 @@ function nativeLockFileIdentity(stat) {
   };
 }
 function sameNativeLockObject(left, right) {
-  if (left.device !== "0" || left.inode !== "0" || right.device !== "0" || right.inode !== "0") {
-    return left.device === right.device && left.inode === right.inode;
+  const leftObject = { dev: left.device, ino: left.inode, birthtime: left.birthtimeNs };
+  const rightObject = { dev: right.device, ino: right.inode, birthtime: right.birthtimeNs };
+  if (hasComparableNativeFileObject(leftObject, rightObject)) {
+    return sameNativeFileObject(leftObject, rightObject);
   }
-  return left.birthtimeNs === right.birthtimeNs && left.size === right.size;
+  return sameNativeFileObject(leftObject, rightObject) && left.size === right.size;
 }
 function sameNativeLockVersion(left, right) {
   return sameNativeLockObject(left, right) && left.size === right.size && left.birthtimeNs === right.birthtimeNs && left.ctimeNs === right.ctimeNs && left.mtimeNs === right.mtimeNs;
@@ -10985,10 +11021,12 @@ function takeLastCompactableOmission(omissions) {
   return null;
 }
 function sameFileIdentity4(left, right) {
-  if (left.dev !== 0 || left.ino !== 0 || right.dev !== 0 || right.ino !== 0) {
-    return left.dev === right.dev && left.ino === right.ino;
+  const leftObject = { ...left, birthtime: left.birthtimeMs };
+  const rightObject = { ...right, birthtime: right.birthtimeMs };
+  if (hasComparableNativeFileObject(leftObject, rightObject)) {
+    return sameNativeFileObject(leftObject, rightObject);
   }
-  return left.birthtimeMs === right.birthtimeMs && left.ctimeMs === right.ctimeMs && left.size === right.size;
+  return sameNativeFileObject(leftObject, rightObject) && left.birthtimeMs === right.birthtimeMs && left.ctimeMs === right.ctimeMs && left.size === right.size;
 }
 async function sha256FileBounded(file, maxBytes, expected, execution) {
   if (!nativeSnapshotExecutionHasBudget(execution)) return { status: "budget-exhausted" };
@@ -12371,14 +12409,22 @@ function asIdentity(stat) {
   };
 }
 function sameFileIdentity5(expected, actual) {
-  const samePlatformIdentity = expected.dev !== 0 || expected.ino !== 0 || actual.dev !== 0 || actual.ino !== 0 ? expected.dev === actual.dev && expected.ino === actual.ino : expected.birthtimeMs === actual.birthtimeMs;
-  return samePlatformIdentity && expected.birthtimeMs === actual.birthtimeMs && expected.ctimeMs === actual.ctimeMs && expected.mtimeMs === actual.mtimeMs && expected.size === actual.size;
+  return sameNativeFileObject(
+    { ...expected, birthtime: expected.birthtimeMs },
+    {
+      ...actual,
+      birthtime: actual.birthtimeMs
+    }
+  ) && expected.birthtimeMs === actual.birthtimeMs && expected.ctimeMs === actual.ctimeMs && expected.mtimeMs === actual.mtimeMs && expected.size === actual.size;
 }
 function sameDirectoryIdentity4(expected, actual) {
-  if (expected.dev !== 0 || expected.ino !== 0 || actual.dev !== 0 || actual.ino !== 0) {
-    return expected.dev === actual.dev && expected.ino === actual.ino;
-  }
-  return expected.birthtimeMs === actual.birthtimeMs;
+  return sameNativeFileObject(
+    { ...expected, birthtime: expected.birthtimeMs },
+    {
+      ...actual,
+      birthtime: actual.birthtimeMs
+    }
+  );
 }
 function runFile(changeDir, kind, relativePath) {
   const expected = NATIVE_RUN_STORAGE[kind];
@@ -16040,16 +16086,21 @@ function isInside5(parent, target) {
   return relative === "" || !path22.isAbsolute(relative) && relative !== ".." && !relative.startsWith(`..${path22.sep}`);
 }
 function sameDirectoryIdentity5(identity, stat) {
-  if (identity.dev !== 0 || identity.ino !== 0 || stat.dev !== 0 || stat.ino !== 0) {
-    return identity.dev === stat.dev && identity.ino === stat.ino;
-  }
-  return identity.birthtimeMs === stat.birthtimeMs;
+  return sameNativeFileObject(
+    { ...identity, birthtime: identity.birthtimeMs },
+    {
+      ...stat,
+      birthtime: stat.birthtimeMs
+    }
+  );
 }
 function sameFileIdentity6(left, right) {
-  if (left.dev !== 0 || left.ino !== 0 || right.dev !== 0 || right.ino !== 0) {
-    return left.dev === right.dev && left.ino === right.ino;
+  const leftObject = { ...left, birthtime: left.birthtimeMs };
+  const rightObject = { ...right, birthtime: right.birthtimeMs };
+  if (hasComparableNativeFileObject(leftObject, rightObject)) {
+    return sameNativeFileObject(leftObject, rightObject);
   }
-  return left.birthtimeMs === right.birthtimeMs && left.ctimeMs === right.ctimeMs && left.size === right.size;
+  return sameNativeFileObject(leftObject, rightObject) && left.birthtimeMs === right.birthtimeMs && left.ctimeMs === right.ctimeMs && left.size === right.size;
 }
 async function captureDirectoryIdentity3(directory) {
   const stat = await fs14.lstat(directory);
@@ -18706,16 +18757,21 @@ var HASH_PATTERN11 = /^[a-f0-9]{64}$/u;
 var RECEIPT_REF_PATTERN = /^runtime\/evidence\/check-receipts\/([a-f0-9]{64})\.json$/u;
 var MAX_NATIVE_CHECK_RECEIPT_BYTES = 512 * 1024;
 function sameDirectoryIdentity6(identity, stat) {
-  if (identity.dev !== 0 || identity.ino !== 0 || stat.dev !== 0 || stat.ino !== 0) {
-    return identity.dev === stat.dev && identity.ino === stat.ino;
-  }
-  return identity.birthtimeMs === stat.birthtimeMs;
+  return sameNativeFileObject(
+    { ...identity, birthtime: identity.birthtimeMs },
+    {
+      ...stat,
+      birthtime: stat.birthtimeMs
+    }
+  );
 }
 function sameFileIdentity7(left, right) {
-  if (left.dev !== 0 || left.ino !== 0 || right.dev !== 0 || right.ino !== 0) {
-    return left.dev === right.dev && left.ino === right.ino;
+  const leftObject = { ...left, birthtime: left.birthtimeMs };
+  const rightObject = { ...right, birthtime: right.birthtimeMs };
+  if (hasComparableNativeFileObject(leftObject, rightObject)) {
+    return sameNativeFileObject(leftObject, rightObject);
   }
-  return left.birthtimeMs === right.birthtimeMs && left.ctimeMs === right.ctimeMs && left.size === right.size;
+  return sameNativeFileObject(leftObject, rightObject) && left.birthtimeMs === right.birthtimeMs && left.ctimeMs === right.ctimeMs && left.size === right.size;
 }
 async function captureDirectoryChain5(root, directory) {
   const lexicalRoot = path26.resolve(root);
@@ -19656,10 +19712,13 @@ function fileVersion(stat) {
   };
 }
 function sameFileObject(expected, actual) {
-  if (expected.dev !== 0 || expected.ino !== 0 || actual.dev !== 0 || actual.ino !== 0) {
-    return expected.dev === actual.dev && expected.ino === actual.ino && expected.birthtimeMs === actual.birthtimeMs;
-  }
-  return expected.birthtimeMs === actual.birthtimeMs;
+  return sameNativeFileObject(
+    { ...expected, birthtime: expected.birthtimeMs },
+    {
+      ...actual,
+      birthtime: actual.birthtimeMs
+    }
+  ) && expected.birthtimeMs === actual.birthtimeMs;
 }
 function sameFileVersion(expected, actual) {
   return sameFileObject(expected, actual) && expected.birthtimeMs === actual.birthtimeMs && expected.ctimeMs === actual.ctimeMs && expected.mtimeMs === actual.mtimeMs && expected.size === actual.size;
@@ -23979,7 +24038,13 @@ var MANAGED_KINDS = [
   "check-receipts"
 ];
 function sameObjectIdentity(left, right) {
-  return left.dev !== 0 || left.ino !== 0 || right.dev !== 0 || right.ino !== 0 ? left.dev === right.dev && left.ino === right.ino : left.birthtimeMs === right.birthtimeMs;
+  return sameNativeFileObject(
+    { ...left, birthtime: left.birthtimeMs },
+    {
+      ...right,
+      birthtime: right.birthtimeMs
+    }
+  );
 }
 function sameIdentity(left, right) {
   return sameObjectIdentity(left, right) && left.birthtimeMs === right.birthtimeMs && left.ctimeMs === right.ctimeMs && left.mtimeMs === right.mtimeMs && left.size === right.size;
@@ -26343,17 +26408,23 @@ function staleReasons(before, after, scope) {
 }
 function sameDirectoryIdentity7(identity, stat) {
   const stableMetadata = identity.birthtimeMs === stat.birthtimeMs && identity.ctimeMs === stat.ctimeMs;
-  if (identity.dev !== 0 || identity.ino !== 0 || stat.dev !== 0 || stat.ino !== 0) {
-    return stableMetadata && identity.dev === stat.dev && identity.ino === stat.ino;
-  }
-  return stableMetadata;
+  return stableMetadata && sameNativeFileObject(
+    { ...identity, birthtime: identity.birthtimeMs },
+    {
+      ...stat,
+      birthtime: stat.birthtimeMs
+    }
+  );
 }
 function sameFileIdentity8(left, right) {
   const stableMetadata = left.birthtimeMs === right.birthtimeMs && left.ctimeMs === right.ctimeMs && left.mtimeMs === right.mtimeMs && left.size === right.size;
-  if (left.dev !== 0 || left.ino !== 0 || right.dev !== 0 || right.ino !== 0) {
-    return stableMetadata && left.dev === right.dev && left.ino === right.ino;
-  }
-  return stableMetadata;
+  return stableMetadata && sameNativeFileObject(
+    { ...left, birthtime: left.birthtimeMs },
+    {
+      ...right,
+      birthtime: right.birthtimeMs
+    }
+  );
 }
 async function captureProjectDirectoryChain(projectRoot, directory) {
   const lexicalRoot = path42.resolve(projectRoot);

--- a/assets/skills/comet/scripts/comet-entry-runtime.mjs
+++ b/assets/skills/comet/scripts/comet-entry-runtime.mjs
@@ -7375,6 +7375,19 @@ import path3 from "path";
 // domains/workflow-contract/project-config.ts
 var import_yaml = __toESM(require_dist(), 1);
 
+// domains/comet-native/native-file-identity.ts
+function hasPlatformIdentity(value) {
+  return value !== 0 && value !== 0n && value !== "0";
+}
+function sameNativeFileObject(left, right) {
+  const comparableDevice = hasPlatformIdentity(left.dev) && hasPlatformIdentity(right.dev);
+  if (comparableDevice && left.dev !== right.dev) return false;
+  const comparableInode = hasPlatformIdentity(left.ino) && hasPlatformIdentity(right.ino);
+  if (comparableInode && left.ino !== right.ino) return false;
+  if (comparableDevice && comparableInode) return true;
+  return left.birthtime === right.birthtime;
+}
+
 // domains/comet-native/native-protected-file.ts
 import { createHash } from "node:crypto";
 import { constants as fsConstants, promises as fs } from "node:fs";
@@ -7391,10 +7404,13 @@ function positiveLimit(value) {
   return value;
 }
 function sameDirectoryIdentity(expected, actual) {
-  if (expected.dev !== 0 || expected.ino !== 0 || actual.dev !== 0 || actual.ino !== 0) {
-    return expected.dev === actual.dev && expected.ino === actual.ino;
-  }
-  return expected.birthtimeMs === actual.birthtimeMs;
+  return sameNativeFileObject(
+    { ...expected, birthtime: expected.birthtimeMs },
+    {
+      ...actual,
+      birthtime: actual.birthtimeMs
+    }
+  );
 }
 function asFileIdentity(stat) {
   return {
@@ -7407,8 +7423,13 @@ function asFileIdentity(stat) {
   };
 }
 function sameFileIdentity(expected, actual) {
-  const sameObject = expected.dev !== 0 || expected.ino !== 0 || actual.dev !== 0 || actual.ino !== 0 ? expected.dev === actual.dev && expected.ino === actual.ino : expected.birthtimeMs === actual.birthtimeMs;
-  return sameObject && expected.birthtimeMs === actual.birthtimeMs && expected.ctimeMs === actual.ctimeMs && expected.mtimeMs === actual.mtimeMs && expected.size === actual.size;
+  return sameNativeFileObject(
+    { ...expected, birthtime: expected.birthtimeMs },
+    {
+      ...actual,
+      birthtime: actual.birthtimeMs
+    }
+  ) && expected.birthtimeMs === actual.birthtimeMs && expected.ctimeMs === actual.ctimeMs && expected.mtimeMs === actual.mtimeMs && expected.size === actual.size;
 }
 async function captureDirectoryIdentity(directory, label) {
   const stat = await fs.lstat(directory);

--- a/assets/skills/comet/scripts/comet-hook-router.mjs
+++ b/assets/skills/comet/scripts/comet-hook-router.mjs
@@ -9054,6 +9054,22 @@ function nativeSensitiveRelativePathReason(relativeRef) {
   return null;
 }
 
+// domains/comet-native/native-file-identity.ts
+function hasPlatformIdentity(value) {
+  return value !== 0 && value !== 0n && value !== "0";
+}
+function hasComparableNativeFileObject(left, right) {
+  return hasPlatformIdentity(left.dev) && hasPlatformIdentity(right.dev) && hasPlatformIdentity(left.ino) && hasPlatformIdentity(right.ino);
+}
+function sameNativeFileObject(left, right) {
+  const comparableDevice = hasPlatformIdentity(left.dev) && hasPlatformIdentity(right.dev);
+  if (comparableDevice && left.dev !== right.dev) return false;
+  const comparableInode = hasPlatformIdentity(left.ino) && hasPlatformIdentity(right.ino);
+  if (comparableInode && left.ino !== right.ino) return false;
+  if (comparableDevice && comparableInode) return true;
+  return left.birthtime === right.birthtime;
+}
+
 // domains/comet-native/native-bounded-file.ts
 var DEFAULT_NATIVE_ARTIFACT_MAX_BYTES = 1024 * 1024;
 function isInside(parent, target) {
@@ -9084,16 +9100,21 @@ function positiveLimit(value) {
   return value;
 }
 function sameDirectoryIdentity(identity, stat) {
-  if (identity.dev !== 0 || identity.ino !== 0 || stat.dev !== 0 || stat.ino !== 0) {
-    return identity.dev === stat.dev && identity.ino === stat.ino;
-  }
-  return identity.birthtimeMs === stat.birthtimeMs;
+  return sameNativeFileObject(
+    { ...identity, birthtime: identity.birthtimeMs },
+    {
+      ...stat,
+      birthtime: stat.birthtimeMs
+    }
+  );
 }
 function sameFileIdentity(left, right) {
-  if (left.dev !== 0 || left.ino !== 0 || right.dev !== 0 || right.ino !== 0) {
-    return left.dev === right.dev && left.ino === right.ino;
+  const leftObject = { ...left, birthtime: left.birthtimeMs };
+  const rightObject = { ...right, birthtime: right.birthtimeMs };
+  if (hasComparableNativeFileObject(leftObject, rightObject)) {
+    return sameNativeFileObject(leftObject, rightObject);
   }
-  return left.birthtimeMs === right.birthtimeMs && left.ctimeMs === right.ctimeMs && left.size === right.size;
+  return sameNativeFileObject(leftObject, rightObject) && left.birthtimeMs === right.birthtimeMs && left.ctimeMs === right.ctimeMs && left.size === right.size;
 }
 async function directoryIdentity(directory) {
   const stat = await fs8.lstat(directory);
@@ -9224,10 +9245,13 @@ function positiveLimit2(value) {
   return value;
 }
 function sameDirectoryIdentity2(expected, actual) {
-  if (expected.dev !== 0 || expected.ino !== 0 || actual.dev !== 0 || actual.ino !== 0) {
-    return expected.dev === actual.dev && expected.ino === actual.ino;
-  }
-  return expected.birthtimeMs === actual.birthtimeMs;
+  return sameNativeFileObject(
+    { ...expected, birthtime: expected.birthtimeMs },
+    {
+      ...actual,
+      birthtime: actual.birthtimeMs
+    }
+  );
 }
 function asFileIdentity(stat) {
   return {
@@ -9240,8 +9264,13 @@ function asFileIdentity(stat) {
   };
 }
 function sameFileIdentity2(expected, actual) {
-  const sameObject = expected.dev !== 0 || expected.ino !== 0 || actual.dev !== 0 || actual.ino !== 0 ? expected.dev === actual.dev && expected.ino === actual.ino : expected.birthtimeMs === actual.birthtimeMs;
-  return sameObject && expected.birthtimeMs === actual.birthtimeMs && expected.ctimeMs === actual.ctimeMs && expected.mtimeMs === actual.mtimeMs && expected.size === actual.size;
+  return sameNativeFileObject(
+    { ...expected, birthtime: expected.birthtimeMs },
+    {
+      ...actual,
+      birthtime: actual.birthtimeMs
+    }
+  ) && expected.birthtimeMs === actual.birthtimeMs && expected.ctimeMs === actual.ctimeMs && expected.mtimeMs === actual.mtimeMs && expected.size === actual.size;
 }
 async function captureDirectoryIdentity(directory, label) {
   const stat = await fs9.lstat(directory);

--- a/assets/skills/comet/scripts/comet-runtime.mjs
+++ b/assets/skills/comet/scripts/comet-runtime.mjs
@@ -11184,6 +11184,7 @@ async function designHandoffMarkdownTraceable(changeDir) {
   if (!await nonempty(markdown))
     return fail(`design handoff markdown is missing or empty: ${markdown}`);
   const source = await fs18.readFile(markdown, "utf8");
+  const lines = new Set(source.split(/\r?\n/u));
   const problems = [];
   if (!/^Generated-by: comet-handoff\.sh$/mu.test(source)) {
     problems.push("handoff markdown is missing Generated-by marker");
@@ -11193,10 +11194,10 @@ async function designHandoffMarkdownTraceable(changeDir) {
   }
   for (const file of await handoffSourceFiles(changeDir)) {
     if (!await exists4(file)) continue;
-    if (!new RegExp(`^- Source: ${file}$`, "mu").test(source)) {
+    if (!lines.has(`- Source: ${file}`)) {
       problems.push(`handoff markdown is missing source reference: ${file}`);
     }
-    if (!new RegExp(`^- SHA256: ${hashFile(file)}$`, "mu").test(source)) {
+    if (!lines.has(`- SHA256: ${hashFile(file)}`)) {
       problems.push(`handoff markdown is missing current sha256 for: ${file}`);
     }
   }

--- a/domains/bundle/bundle-platform.ts
+++ b/domains/bundle/bundle-platform.ts
@@ -133,11 +133,7 @@ function scriptDestination(
   bundleName: string,
   script: BundleCompilerIr['scripts'][number],
 ): string {
-  return path.join(
-    target.layout.scriptsRoot!,
-    bundleName,
-    ...script.path.replace(/^scripts\//, 'scripts/').split('/'),
-  );
+  return path.join(target.layout.scriptsRoot!, bundleName, ...script.path.split('/'));
 }
 
 function scriptCommand(script: BundleCompilerIr['scripts'][number], destination: string): string {

--- a/domains/comet-classic/classic-guard.ts
+++ b/domains/comet-classic/classic-guard.ts
@@ -657,6 +657,7 @@ async function designHandoffMarkdownTraceable(changeDir: string): Promise<CheckR
   if (!(await nonempty(markdown)))
     return fail(`design handoff markdown is missing or empty: ${markdown}`);
   const source = await fs.readFile(markdown, 'utf8');
+  const lines = new Set(source.split(/\r?\n/u));
   const problems: string[] = [];
   if (!/^Generated-by: comet-handoff\.sh$/mu.test(source)) {
     problems.push('handoff markdown is missing Generated-by marker');
@@ -666,10 +667,10 @@ async function designHandoffMarkdownTraceable(changeDir: string): Promise<CheckR
   }
   for (const file of await handoffSourceFiles(changeDir)) {
     if (!(await exists(file))) continue;
-    if (!new RegExp(`^- Source: ${file}$`, 'mu').test(source)) {
+    if (!lines.has(`- Source: ${file}`)) {
       problems.push(`handoff markdown is missing source reference: ${file}`);
     }
-    if (!new RegExp(`^- SHA256: ${hashFile(file)}$`, 'mu').test(source)) {
+    if (!lines.has(`- SHA256: ${hashFile(file)}`)) {
       problems.push(`handoff markdown is missing current sha256 for: ${file}`);
     }
   }

--- a/domains/comet-native/native-archive-transaction.ts
+++ b/domains/comet-native/native-archive-transaction.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
 import { atomicWriteJson } from './native-atomic-file.js';
+import { sameNativeFileObject } from './native-file-identity.js';
 import {
   inspectNativeArchiveContent,
   type NativeArchiveContentIdentity,
@@ -189,14 +190,15 @@ function sameFileObject(
   expected: NativeArchiveFileObjectIdentity,
   actual: NativeArchiveFileObjectIdentity,
 ): boolean {
-  if (expected.dev !== 0 || expected.ino !== 0 || actual.dev !== 0 || actual.ino !== 0) {
-    return (
-      expected.dev === actual.dev &&
-      expected.ino === actual.ino &&
-      expected.birthtimeMs === actual.birthtimeMs
-    );
-  }
-  return expected.birthtimeMs === actual.birthtimeMs;
+  return (
+    sameNativeFileObject(
+      { ...expected, birthtime: expected.birthtimeMs },
+      {
+        ...actual,
+        birthtime: actual.birthtimeMs,
+      },
+    ) && expected.birthtimeMs === actual.birthtimeMs
+  );
 }
 
 function sameFileVersion(

--- a/domains/comet-native/native-atomic-file.ts
+++ b/domains/comet-native/native-atomic-file.ts
@@ -2,6 +2,8 @@ import { randomUUID } from 'crypto';
 import { promises as fs } from 'fs';
 import path from 'path';
 
+import { hasComparableNativeFileObject, sameNativeFileObject } from './native-file-identity.js';
+
 export interface NativeAtomicWriteOptions {
   containedRoot?: string;
   beforeTemporaryOpen?: () => void | Promise<void>;
@@ -26,17 +28,23 @@ function isInside(parent: string, target: string): boolean {
 }
 
 function sameDirectoryIdentity(identity: DirectoryIdentity, stat: import('fs').Stats): boolean {
-  if (identity.dev !== 0 || identity.ino !== 0 || stat.dev !== 0 || stat.ino !== 0) {
-    return identity.dev === stat.dev && identity.ino === stat.ino;
-  }
-  return identity.birthtimeMs === stat.birthtimeMs;
+  return sameNativeFileObject(
+    { ...identity, birthtime: identity.birthtimeMs },
+    {
+      ...stat,
+      birthtime: stat.birthtimeMs,
+    },
+  );
 }
 
 function sameFileIdentity(left: import('fs').Stats, right: import('fs').Stats): boolean {
-  if (left.dev !== 0 || left.ino !== 0 || right.dev !== 0 || right.ino !== 0) {
-    return left.dev === right.dev && left.ino === right.ino;
+  const leftObject = { ...left, birthtime: left.birthtimeMs };
+  const rightObject = { ...right, birthtime: right.birthtimeMs };
+  if (hasComparableNativeFileObject(leftObject, rightObject)) {
+    return sameNativeFileObject(leftObject, rightObject);
   }
   return (
+    sameNativeFileObject(leftObject, rightObject) &&
     left.birthtimeMs === right.birthtimeMs &&
     left.ctimeMs === right.ctimeMs &&
     left.size === right.size

--- a/domains/comet-native/native-bounded-file.ts
+++ b/domains/comet-native/native-bounded-file.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { TextDecoder } from 'node:util';
 
 import { nativeSensitiveRelativePathReason } from './native-sensitive-paths.js';
+import { hasComparableNativeFileObject, sameNativeFileObject } from './native-file-identity.js';
 
 export const DEFAULT_NATIVE_ARTIFACT_MAX_BYTES = 1024 * 1024;
 
@@ -76,17 +77,23 @@ function sameDirectoryIdentity(
   identity: DirectoryIdentity,
   stat: import('node:fs').Stats,
 ): boolean {
-  if (identity.dev !== 0 || identity.ino !== 0 || stat.dev !== 0 || stat.ino !== 0) {
-    return identity.dev === stat.dev && identity.ino === stat.ino;
-  }
-  return identity.birthtimeMs === stat.birthtimeMs;
+  return sameNativeFileObject(
+    { ...identity, birthtime: identity.birthtimeMs },
+    {
+      ...stat,
+      birthtime: stat.birthtimeMs,
+    },
+  );
 }
 
 function sameFileIdentity(left: import('node:fs').Stats, right: import('node:fs').Stats): boolean {
-  if (left.dev !== 0 || left.ino !== 0 || right.dev !== 0 || right.ino !== 0) {
-    return left.dev === right.dev && left.ino === right.ino;
+  const leftObject = { ...left, birthtime: left.birthtimeMs };
+  const rightObject = { ...right, birthtime: right.birthtimeMs };
+  if (hasComparableNativeFileObject(leftObject, rightObject)) {
+    return sameNativeFileObject(leftObject, rightObject);
   }
   return (
+    sameNativeFileObject(leftObject, rightObject) &&
     left.birthtimeMs === right.birthtimeMs &&
     left.ctimeMs === right.ctimeMs &&
     left.size === right.size

--- a/domains/comet-native/native-check-receipt-storage.ts
+++ b/domains/comet-native/native-check-receipt-storage.ts
@@ -5,6 +5,7 @@ import { atomicWriteJson } from './native-atomic-file.js';
 import { nativeChangeDir } from './native-change.js';
 import { parseNativeCheckReceipt, type NativeCheckReceipt } from './native-check-receipt-model.js';
 import { isInsidePath, resolveContainedNativePath } from './native-paths.js';
+import { hasComparableNativeFileObject, sameNativeFileObject } from './native-file-identity.js';
 import type { NativeProjectPaths } from './native-types.js';
 
 const HASH_PATTERN = /^[a-f0-9]{64}$/u;
@@ -23,17 +24,23 @@ function sameDirectoryIdentity(
   identity: DirectoryIdentity,
   stat: import('node:fs').Stats,
 ): boolean {
-  if (identity.dev !== 0 || identity.ino !== 0 || stat.dev !== 0 || stat.ino !== 0) {
-    return identity.dev === stat.dev && identity.ino === stat.ino;
-  }
-  return identity.birthtimeMs === stat.birthtimeMs;
+  return sameNativeFileObject(
+    { ...identity, birthtime: identity.birthtimeMs },
+    {
+      ...stat,
+      birthtime: stat.birthtimeMs,
+    },
+  );
 }
 
 function sameFileIdentity(left: import('node:fs').Stats, right: import('node:fs').Stats): boolean {
-  if (left.dev !== 0 || left.ino !== 0 || right.dev !== 0 || right.ino !== 0) {
-    return left.dev === right.dev && left.ino === right.ino;
+  const leftObject = { ...left, birthtime: left.birthtimeMs };
+  const rightObject = { ...right, birthtime: right.birthtimeMs };
+  if (hasComparableNativeFileObject(leftObject, rightObject)) {
+    return sameNativeFileObject(leftObject, rightObject);
   }
   return (
+    sameNativeFileObject(leftObject, rightObject) &&
     left.birthtimeMs === right.birthtimeMs &&
     left.ctimeMs === right.ctimeMs &&
     left.size === right.size

--- a/domains/comet-native/native-check-receipt.ts
+++ b/domains/comet-native/native-check-receipt.ts
@@ -16,6 +16,7 @@ import {
 import { writeNativeCheckReceipt } from './native-check-receipt-storage.js';
 import { collectNativeContractFiles } from './native-contract-files.js';
 import { readNativeImplementationScopeBundle } from './native-evidence-storage.js';
+import { sameNativeFileObject } from './native-file-identity.js';
 import { isInsidePath } from './native-paths.js';
 import { createNativeContentSnapshot } from './native-snapshot.js';
 import type {
@@ -177,10 +178,16 @@ function sameDirectoryIdentity(
 ): boolean {
   const stableMetadata =
     identity.birthtimeMs === stat.birthtimeMs && identity.ctimeMs === stat.ctimeMs;
-  if (identity.dev !== 0 || identity.ino !== 0 || stat.dev !== 0 || stat.ino !== 0) {
-    return stableMetadata && identity.dev === stat.dev && identity.ino === stat.ino;
-  }
-  return stableMetadata;
+  return (
+    stableMetadata &&
+    sameNativeFileObject(
+      { ...identity, birthtime: identity.birthtimeMs },
+      {
+        ...stat,
+        birthtime: stat.birthtimeMs,
+      },
+    )
+  );
 }
 
 function sameFileIdentity(left: import('node:fs').Stats, right: import('node:fs').Stats): boolean {
@@ -189,10 +196,16 @@ function sameFileIdentity(left: import('node:fs').Stats, right: import('node:fs'
     left.ctimeMs === right.ctimeMs &&
     left.mtimeMs === right.mtimeMs &&
     left.size === right.size;
-  if (left.dev !== 0 || left.ino !== 0 || right.dev !== 0 || right.ino !== 0) {
-    return stableMetadata && left.dev === right.dev && left.ino === right.ino;
-  }
-  return stableMetadata;
+  return (
+    stableMetadata &&
+    sameNativeFileObject(
+      { ...left, birthtime: left.birthtimeMs },
+      {
+        ...right,
+        birthtime: right.birthtimeMs,
+      },
+    )
+  );
 }
 
 async function captureProjectDirectoryChain(

--- a/domains/comet-native/native-evidence-retention.ts
+++ b/domains/comet-native/native-evidence-retention.ts
@@ -17,6 +17,7 @@ import { isInsidePath, resolveContainedNativePath } from './native-paths.js';
 import { inspectPendingNativeSchemaMigration } from './native-schema-migration.js';
 import { inspectPendingNativeTransition } from './native-transition-journal.js';
 import { readNativeTransaction } from './native-transaction.js';
+import { sameNativeFileObject } from './native-file-identity.js';
 import type { NativeDoctorFinding, NativeProjectPaths } from './native-types.js';
 import {
   parseNativeImplementationScope,
@@ -113,9 +114,13 @@ function sameObjectIdentity(
   left: NativeFileIdentity,
   right: Pick<import('node:fs').Stats, keyof NativeFileIdentity>,
 ): boolean {
-  return left.dev !== 0 || left.ino !== 0 || right.dev !== 0 || right.ino !== 0
-    ? left.dev === right.dev && left.ino === right.ino
-    : left.birthtimeMs === right.birthtimeMs;
+  return sameNativeFileObject(
+    { ...left, birthtime: left.birthtimeMs },
+    {
+      ...right,
+      birthtime: right.birthtimeMs,
+    },
+  );
 }
 
 function sameIdentity(

--- a/domains/comet-native/native-evidence-storage.ts
+++ b/domains/comet-native/native-evidence-storage.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { atomicWriteJson } from './native-atomic-file.js';
 import { nativeChangeDir } from './native-change.js';
 import { resolveContainedNativePath } from './native-paths.js';
+import { hasComparableNativeFileObject, sameNativeFileObject } from './native-file-identity.js';
 import type { NativeProjectPaths } from './native-types.js';
 import {
   parseNativeImplementationScopeBundle,
@@ -61,17 +62,23 @@ function sameDirectoryIdentity(
   identity: DirectoryIdentity,
   stat: import('node:fs').Stats,
 ): boolean {
-  if (identity.dev !== 0 || identity.ino !== 0 || stat.dev !== 0 || stat.ino !== 0) {
-    return identity.dev === stat.dev && identity.ino === stat.ino;
-  }
-  return identity.birthtimeMs === stat.birthtimeMs;
+  return sameNativeFileObject(
+    { ...identity, birthtime: identity.birthtimeMs },
+    {
+      ...stat,
+      birthtime: stat.birthtimeMs,
+    },
+  );
 }
 
 function sameFileIdentity(left: import('node:fs').Stats, right: import('node:fs').Stats): boolean {
-  if (left.dev !== 0 || left.ino !== 0 || right.dev !== 0 || right.ino !== 0) {
-    return left.dev === right.dev && left.ino === right.ino;
+  const leftObject = { ...left, birthtime: left.birthtimeMs };
+  const rightObject = { ...right, birthtime: right.birthtimeMs };
+  if (hasComparableNativeFileObject(leftObject, rightObject)) {
+    return sameNativeFileObject(leftObject, rightObject);
   }
   return (
+    sameNativeFileObject(leftObject, rightObject) &&
     left.birthtimeMs === right.birthtimeMs &&
     left.ctimeMs === right.ctimeMs &&
     left.size === right.size

--- a/domains/comet-native/native-file-identity.ts
+++ b/domains/comet-native/native-file-identity.ts
@@ -1,0 +1,37 @@
+export type NativeFileIdentityScalar = number | bigint | string;
+
+export interface NativeFileObjectIdentity {
+  dev: NativeFileIdentityScalar;
+  ino: NativeFileIdentityScalar;
+  birthtime: NativeFileIdentityScalar;
+}
+
+function hasPlatformIdentity(value: NativeFileIdentityScalar): boolean {
+  return value !== 0 && value !== 0n && value !== '0';
+}
+
+export function hasComparableNativeFileObject(
+  left: NativeFileObjectIdentity,
+  right: NativeFileObjectIdentity,
+): boolean {
+  return (
+    hasPlatformIdentity(left.dev) &&
+    hasPlatformIdentity(right.dev) &&
+    hasPlatformIdentity(left.ino) &&
+    hasPlatformIdentity(right.ino)
+  );
+}
+
+export function sameNativeFileObject(
+  left: NativeFileObjectIdentity,
+  right: NativeFileObjectIdentity,
+): boolean {
+  const comparableDevice = hasPlatformIdentity(left.dev) && hasPlatformIdentity(right.dev);
+  if (comparableDevice && left.dev !== right.dev) return false;
+
+  const comparableInode = hasPlatformIdentity(left.ino) && hasPlatformIdentity(right.ino);
+  if (comparableInode && left.ino !== right.ino) return false;
+
+  if (comparableDevice && comparableInode) return true;
+  return left.birthtime === right.birthtime;
+}

--- a/domains/comet-native/native-lock.ts
+++ b/domains/comet-native/native-lock.ts
@@ -5,6 +5,7 @@ import os from 'os';
 import path from 'path';
 
 import { resolveContainedNativePath } from './native-paths.js';
+import { hasComparableNativeFileObject, sameNativeFileObject } from './native-file-identity.js';
 import type { NativeProjectPaths } from './native-types.js';
 
 const NATIVE_LOCK_MAX_BYTES = 16 * 1024;
@@ -101,10 +102,12 @@ function sameNativeLockObject(
   left: NativeLockFileIdentity,
   right: NativeLockFileIdentity,
 ): boolean {
-  if (left.device !== '0' || left.inode !== '0' || right.device !== '0' || right.inode !== '0') {
-    return left.device === right.device && left.inode === right.inode;
+  const leftObject = { dev: left.device, ino: left.inode, birthtime: left.birthtimeNs };
+  const rightObject = { dev: right.device, ino: right.inode, birthtime: right.birthtimeNs };
+  if (hasComparableNativeFileObject(leftObject, rightObject)) {
+    return sameNativeFileObject(leftObject, rightObject);
   }
-  return left.birthtimeNs === right.birthtimeNs && left.size === right.size;
+  return sameNativeFileObject(leftObject, rightObject) && left.size === right.size;
 }
 
 function sameNativeLockVersion(

--- a/domains/comet-native/native-protected-file.ts
+++ b/domains/comet-native/native-protected-file.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { TextDecoder } from 'node:util';
 
 import { atomicWriteBytes } from './native-atomic-file.js';
+import { sameNativeFileObject } from './native-file-identity.js';
 
 export interface NativeProtectedFileHooks {
   afterParentChainCaptured?: () => void | Promise<void>;
@@ -59,10 +60,13 @@ function sameDirectoryIdentity(
   expected: DirectoryIdentity,
   actual: import('node:fs').Stats,
 ): boolean {
-  if (expected.dev !== 0 || expected.ino !== 0 || actual.dev !== 0 || actual.ino !== 0) {
-    return expected.dev === actual.dev && expected.ino === actual.ino;
-  }
-  return expected.birthtimeMs === actual.birthtimeMs;
+  return sameNativeFileObject(
+    { ...expected, birthtime: expected.birthtimeMs },
+    {
+      ...actual,
+      birthtime: actual.birthtimeMs,
+    },
+  );
 }
 
 function asFileIdentity(stat: import('node:fs').Stats): FileIdentity {
@@ -77,12 +81,14 @@ function asFileIdentity(stat: import('node:fs').Stats): FileIdentity {
 }
 
 function sameFileIdentity(expected: FileIdentity, actual: import('node:fs').Stats): boolean {
-  const sameObject =
-    expected.dev !== 0 || expected.ino !== 0 || actual.dev !== 0 || actual.ino !== 0
-      ? expected.dev === actual.dev && expected.ino === actual.ino
-      : expected.birthtimeMs === actual.birthtimeMs;
   return (
-    sameObject &&
+    sameNativeFileObject(
+      { ...expected, birthtime: expected.birthtimeMs },
+      {
+        ...actual,
+        birthtime: actual.birthtimeMs,
+      },
+    ) &&
     expected.birthtimeMs === actual.birthtimeMs &&
     expected.ctimeMs === actual.ctimeMs &&
     expected.mtimeMs === actual.mtimeMs &&

--- a/domains/comet-native/native-run-store.ts
+++ b/domains/comet-native/native-run-store.ts
@@ -8,6 +8,7 @@ import { parseStoredRunStateValue, startRunWithStorage } from '../engine/storage
 import type { Checkpoint, EngineAction, RunState, TrajectoryEvent } from '../engine/types.js';
 import type { SkillPackage } from '../skill/types.js';
 import { atomicWriteText } from './native-atomic-file.js';
+import { sameNativeFileObject } from './native-file-identity.js';
 
 export const NATIVE_RUN_IO_LIMITS = {
   runStateBytes: 256 * 1024,
@@ -86,12 +87,14 @@ function asIdentity(stat: import('node:fs').Stats): FileIdentity {
 }
 
 function sameFileIdentity(expected: FileIdentity, actual: import('node:fs').Stats): boolean {
-  const samePlatformIdentity =
-    expected.dev !== 0 || expected.ino !== 0 || actual.dev !== 0 || actual.ino !== 0
-      ? expected.dev === actual.dev && expected.ino === actual.ino
-      : expected.birthtimeMs === actual.birthtimeMs;
   return (
-    samePlatformIdentity &&
+    sameNativeFileObject(
+      { ...expected, birthtime: expected.birthtimeMs },
+      {
+        ...actual,
+        birthtime: actual.birthtimeMs,
+      },
+    ) &&
     expected.birthtimeMs === actual.birthtimeMs &&
     expected.ctimeMs === actual.ctimeMs &&
     expected.mtimeMs === actual.mtimeMs &&
@@ -103,10 +106,13 @@ function sameDirectoryIdentity(
   expected: DirectoryIdentity,
   actual: import('node:fs').Stats,
 ): boolean {
-  if (expected.dev !== 0 || expected.ino !== 0 || actual.dev !== 0 || actual.ino !== 0) {
-    return expected.dev === actual.dev && expected.ino === actual.ino;
-  }
-  return expected.birthtimeMs === actual.birthtimeMs;
+  return sameNativeFileObject(
+    { ...expected, birthtime: expected.birthtimeMs },
+    {
+      ...actual,
+      birthtime: actual.birthtimeMs,
+    },
+  );
 }
 
 function runFile(changeDir: string, kind: NativeRunFileKind, relativePath?: string): string {

--- a/domains/comet-native/native-snapshot.ts
+++ b/domains/comet-native/native-snapshot.ts
@@ -5,6 +5,7 @@ import path from 'path';
 
 import { atomicWriteJson } from './native-atomic-file.js';
 import { sha256Text } from './native-hash.js';
+import { hasComparableNativeFileObject, sameNativeFileObject } from './native-file-identity.js';
 import { isInsidePath, resolveContainedNativePath } from './native-paths.js';
 import { readNativeProtectedTextFile } from './native-protected-file.js';
 import { nativeSensitiveRelativePathReason } from './native-sensitive-paths.js';
@@ -1362,10 +1363,13 @@ function takeLastCompactableOmission(
 }
 
 function sameFileIdentity(left: import('fs').Stats, right: import('fs').Stats): boolean {
-  if (left.dev !== 0 || left.ino !== 0 || right.dev !== 0 || right.ino !== 0) {
-    return left.dev === right.dev && left.ino === right.ino;
+  const leftObject = { ...left, birthtime: left.birthtimeMs };
+  const rightObject = { ...right, birthtime: right.birthtimeMs };
+  if (hasComparableNativeFileObject(leftObject, rightObject)) {
+    return sameNativeFileObject(leftObject, rightObject);
   }
   return (
+    sameNativeFileObject(leftObject, rightObject) &&
     left.birthtimeMs === right.birthtimeMs &&
     left.ctimeMs === right.ctimeMs &&
     left.size === right.size

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rpamis/comet",
-  "version": "0.4.0-beta.7",
+  "version": "0.4.0-beta.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rpamis/comet",
-      "version": "0.4.0-beta.7",
+      "version": "0.4.0-beta.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3790,9 +3790,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,14 @@
   },
   "packageManager": "pnpm@10.18.3",
   "overrides": {
+    "brace-expansion": "5.0.7",
     "esbuild": "0.28.1"
+  },
+  "pnpm": {
+    "overrides": {
+      "brace-expansion": "5.0.7",
+      "esbuild": "0.28.1"
+    }
   },
   "engines": {
     "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rpamis/comet",
-  "version": "0.4.0-beta.7",
+  "version": "0.4.0-beta.8",
   "description": "Agent Skill Harness For Turning Ideas Into Evaluated Workflows",
   "keywords": [
     "comet",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion: 5.0.7
+  esbuild: 0.28.1
+
 importers:
 
   .:
@@ -1340,8 +1344,8 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -3739,7 +3743,7 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4500,7 +4504,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   ms@2.1.3: {}
 

--- a/scripts/lint/architecture.mjs
+++ b/scripts/lint/architecture.mjs
@@ -76,7 +76,13 @@ function walkFiles(relativePath, ignoredNames = new Set(), ignoredRelativePaths 
       const entryAbsolutePath = path.join(currentAbsolutePath, entry);
       const entryRelativePath = path.join(currentRelativePath, entry).replaceAll(path.sep, '/');
       if (ignoredRelativePaths.has(entryRelativePath)) continue;
-      if (entryRelativePath === 'eval/local/logs' || entryRelativePath === 'eval/.venv') continue;
+      if (
+        entryRelativePath === 'eval/local/logs' ||
+        entryRelativePath === 'eval/langsmith/logs' ||
+        entryRelativePath === 'eval/.venv'
+      ) {
+        continue;
+      }
       const stats = statSync(entryAbsolutePath);
       if (stats.isDirectory()) {
         visit(entryAbsolutePath, entryRelativePath);

--- a/test/app/cli-help.test.ts
+++ b/test/app/cli-help.test.ts
@@ -35,10 +35,10 @@ describe('CLI help text', () => {
     expect(help.status, help.stderr).toBe(0);
     expect(help.stdout).toContain(tagline);
     expect(packageJson.description).toBe(tagline);
-    expect(packageJson.version).toBe('0.4.0-beta.7');
-    expect(packageLock.version).toBe('0.4.0-beta.7');
-    expect(packageLock.packages[''].version).toBe('0.4.0-beta.7');
-    expect(assetsManifest.version).toBe('0.4.0-beta.7');
+    expect(packageJson.version).toBe('0.4.0-beta.8');
+    expect(packageLock.version).toBe('0.4.0-beta.8');
+    expect(packageLock.packages[''].version).toBe('0.4.0-beta.8');
+    expect(assetsManifest.version).toBe('0.4.0-beta.8');
   });
 
   it('marks bundle as the advanced backend and skill Engine runs as advanced', () => {

--- a/test/domains/comet-classic/comet-scripts.test.ts
+++ b/test/domains/comet-classic/comet-scripts.test.ts
@@ -1577,6 +1577,70 @@ describe('comet scripts', () => {
     expect(result.stderr).toContain('[PASS] Design Doc declares OpenSpec as canonical spec');
   }, 20_000);
 
+  it('accepts handoff source paths containing regular expression metacharacters', async () => {
+    const handoffScript = path.join(tmpDir, 'scripts', 'comet-handoff.mjs');
+    await createChange(
+      tmpDir,
+      'regex-source-path',
+      [
+        'workflow: full',
+        'phase: design',
+        'build_mode: null',
+        'build_pause: null',
+        'tdd_mode: null',
+        'isolation: null',
+        'verify_mode: null',
+        'design_doc: null',
+        'plan: null',
+        'verify_result: pending',
+        'verified_at: null',
+        'archived: false',
+        'auto_transition: true',
+        '',
+      ].join('\n'),
+      '- [ ] verify escaped source paths\n',
+    );
+    await writeFile(
+      path.join(
+        tmpDir,
+        'openspec',
+        'changes',
+        'regex-source-path',
+        'specs',
+        'capability[',
+        'spec.md',
+      ),
+      'delta spec\n',
+    );
+
+    const handoff = runNode(tmpDir, handoffScript, ['regex-source-path', 'design', '--write']);
+    expect(handoff.status).toBe(0);
+
+    await writeFile(
+      path.join(tmpDir, 'docs', 'superpowers', 'specs', 'regex-source-path.md'),
+      [
+        '---',
+        'comet_change: regex-source-path',
+        'role: technical-design',
+        'canonical_spec: openspec',
+        '---',
+        '',
+      ].join('\n'),
+    );
+    const state = runNode(tmpDir, stateScript, [
+      'set',
+      'regex-source-path',
+      'design_doc',
+      'docs/superpowers/specs/regex-source-path.md',
+    ]);
+    expect(state.status).toBe(0);
+
+    const result = runNode(tmpDir, guardScript, ['regex-source-path', 'design']);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).toContain('[PASS] design handoff markdown is traceable');
+  }, 20_000);
+
   it('generates a beta spec projection handoff with verbatim spec content', async () => {
     const handoffScript = path.join(tmpDir, 'scripts', 'comet-handoff.mjs');
     await createChange(

--- a/test/domains/comet-native/native-bounded-file.test.ts
+++ b/test/domains/comet-native/native-bounded-file.test.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { readNativeBoundedTextFile } from '../../../domains/comet-native/native-bounded-file.js';
 
@@ -14,7 +14,28 @@ describe('Native bounded artifact reader', () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('rejects a partial Windows identity when the available inode differs', async () => {
+    const file = path.join(root, 'report.md');
+    await fs.writeFile(file, 'stable');
+    const originalLstat = fs.lstat.bind(fs);
+    vi.spyOn(fs, 'lstat').mockImplementation(async (...args) => {
+      const stat = await originalLstat(...args);
+      if (path.resolve(args[0].toString()) === file) {
+        Object.defineProperties(stat, {
+          dev: { value: 0 },
+          ino: { value: stat.ino + 1_000_000 },
+        });
+      }
+      return stat;
+    });
+
+    await expect(readNativeBoundedTextFile({ root, ref: 'report.md' })).rejects.toThrow(
+      'changed while opening',
+    );
   });
 
   it('returns only a normalized ref, bounded content identity, and UTF-8 text', async () => {

--- a/test/domains/comet-native/native-file-identity.test.ts
+++ b/test/domains/comet-native/native-file-identity.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  hasComparableNativeFileObject,
+  sameNativeFileObject,
+} from '../../../domains/comet-native/native-file-identity.js';
+
+describe('Native file object identity', () => {
+  it('requires a complete device and inode pair before metadata can be skipped', () => {
+    const left = { dev: 7, ino: 0, birthtime: 100 };
+    const right = { dev: 7, ino: 0, birthtime: 200 };
+
+    expect(hasComparableNativeFileObject(left, right)).toBe(false);
+    expect(sameNativeFileObject(left, right)).toBe(false);
+  });
+
+  it('uses matching inode and birth time when one Windows device id is unavailable', () => {
+    const pathStat = { dev: 0, ino: 42, birthtime: 100 };
+    const handleStat = { dev: 7, ino: 42, birthtime: 100 };
+
+    expect(hasComparableNativeFileObject(pathStat, handleStat)).toBe(false);
+    expect(sameNativeFileObject(pathStat, handleStat)).toBe(true);
+    expect(sameNativeFileObject(pathStat, { ...handleStat, ino: 43 })).toBe(false);
+  });
+});

--- a/test/domains/comet-native/native-protected-file.test.ts
+++ b/test/domains/comet-native/native-protected-file.test.ts
@@ -3,7 +3,7 @@ import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   copyNativeProtectedFile,
@@ -29,7 +29,33 @@ describe('Native protected file I/O', () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await fs.rm(sandbox, { recursive: true, force: true });
+  });
+
+  it('reads a stable file when Windows path stats omit the device id', async () => {
+    const source = path.join(sourceRoot, 'nested', 'spec.md');
+    await fs.writeFile(source, 'trusted source\n');
+    const originalLstat = fs.lstat.bind(fs);
+    vi.spyOn(fs, 'lstat').mockImplementation(async (...args) => {
+      const stat = await originalLstat(...args);
+      if (path.resolve(args[0].toString()) === source) {
+        Object.defineProperty(stat, 'dev', { value: 0 });
+      }
+      return stat;
+    });
+
+    await expect(
+      readNativeProtectedFile({
+        root: sourceRoot,
+        file: source,
+        maxBytes: 1024,
+        label: 'Windows protected file',
+      }),
+    ).resolves.toMatchObject({
+      bytes: Buffer.from('trusted source\n'),
+      size: 15,
+    });
   });
 
   it('stops protected directory enumeration at its entry budget', async () => {

--- a/test/scripts/architecture-lint.test.ts
+++ b/test/scripts/architecture-lint.test.ts
@@ -96,6 +96,43 @@ async function makeMinimalRepository(): Promise<string> {
 }
 
 describe('architecture lint', () => {
+  it('ignores LangSmith experiment logs without excluding LangSmith source', async () => {
+    const root = await makeMinimalRepository();
+    await writeFile(root, '.gitignore', 'logs\n');
+    await writeFile(
+      root,
+      'eval/langsmith/logs/experiments/run/artifacts/skill/scripts/runtime.mjs',
+      'export {};\n',
+    );
+
+    const ignoredLog = spawnSync(
+      process.execPath,
+      [path.resolve('scripts', 'lint', 'architecture.mjs')],
+      {
+        cwd: root,
+        encoding: 'utf8',
+      },
+    );
+
+    expect(ignoredLog.stderr).toBe('');
+    expect(ignoredLog.status).toBe(0);
+
+    await writeFile(root, 'eval/langsmith/source.mjs', 'export {};\n');
+    const realSource = spawnSync(
+      process.execPath,
+      [path.resolve('scripts', 'lint', 'architecture.mjs')],
+      {
+        cwd: root,
+        encoding: 'utf8',
+      },
+    );
+
+    expect(realSource.status).toBe(1);
+    expect(realSource.stderr).toContain(
+      'eval/langsmith/source.mjs is code outside an approved code root',
+    );
+  });
+
   it('ignores nested local cache directories listed in .gitignore', async () => {
     const root = await makeMinimalRepository();
     await writeFile(root, '.gitignore', 'eval/.cache/\neval/**/.cache/\neval/**/.pytest*/\n');


### PR DESCRIPTION
## ✨ Summary

<!-- What changed, and why? Link related issues when available. -->

## 🎯 Scope

<!-- Check all areas touched by this PR. -->

- [ ] CLI commands (`init`, `status`, `doctor`, `update`)
- [ ] Core installer / platform detection
- [ ] Comet skills (`assets/skills/`, `assets/skills-zh/`)
- [ ] Comet shell scripts (`assets/skills/comet/scripts/`)
- [ ] Tests / CI
- [ ] Documentation / changelog
- [ ] Other:

## 🧪 Testing

<!-- List the commands you ran and summarize the result. -->

- [ ] `pnpm build`
- [ ] `pnpm lint`
- [ ] `pnpm run lint:architecture`
- [ ] `pnpm format:check`
- [ ] `pnpm test`
- [ ] `pnpm test -- test/domains/comet-classic/comet-scripts.test.ts`
- [ ] Not run:

## ✅ Checklist

- [ ] PR title follows Conventional Commits, for example `fix: handle project-scope init`
- [ ] User-facing behavior is documented in `README.md`, `README-zh.md`, or `CONTRIBUTING.md`
- [ ] `CHANGELOG.md` is updated when behavior changes
- [ ] Skill changes were made in Chinese first when applicable, then synced to English
- [ ] New scripts are included in `assets/manifest.json` and relevant tests
- [ ] Shell scripts remain portable across macOS, Linux, and Windows Git Bash
- [ ] No unrelated generated files or local artifacts are included

## 👀 Notes for Reviewers

<!-- Anything reviewers should pay special attention to? -->

## Summary by Sourcery

Improve native file identity handling across platforms, harden development-time dependency resolution, and tighten classic handoff and architecture validation behavior while bumping the release to 0.4.0-beta.8.

New Features:
- Introduce a shared native file object identity helper that encapsulates platform-aware device, inode, and birthtime comparison semantics.

Bug Fixes:
- Fix native file and directory validation to correctly treat partial Windows device/inode metadata as stable when appropriate, avoiding spurious `changed while opening` errors in native commands.
- Correct classic design handoff validation to match recorded source paths and hashes by exact lines instead of regular expressions, preventing malformed spec directory names from breaking guard checks.
- Adjust bundle script destination path computation so generated script paths are joined directly from the compiler IR without redundant prefix manipulation.
- Update architecture lint to ignore LangSmith experiment log trees while still enforcing that real LangSmith source files remain within approved code roots.

Enhancements:
- Refactor native lock, snapshot, archive, evidence, check receipt, run store, and atomic/bounded file identity checks to consistently rely on the shared native file identity helper.
- Align comet runtime and entry runtimes with the new native file identity logic to maintain consistent behavior between TypeScript domains and generated skill scripts.

Build:
- Pin `brace-expansion` to the patched 5.0.7 release for both npm and pnpm overrides to mitigate excessive CPU usage from malicious brace patterns.

Documentation:
- Document the Windows native file validation fix and security hardening changes in the 0.4.0-beta.8 CHANGELOG entry.

Tests:
- Add native file identity unit tests to cover partial and mismatched device/inode scenarios, including Windows-specific edge cases.
- Extend native bounded and protected file tests to verify behavior when Windows path stats omit or alter device/inode fields.
- Add classic comet scripts tests to ensure handoff validation accepts source paths containing regular expression metacharacters.
- Extend architecture lint tests to confirm LangSmith experiment logs are ignored while LangSmith source files trigger violations.
- Update CLI help tests to assert the new 0.4.0-beta.8 version across package metadata and assets manifest.

Chores:
- Bump package and assets manifest versions from 0.4.0-beta.7 to 0.4.0-beta.8 and sync lockfiles accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows file validation to avoid false “changed while opening” errors while preserving file replacement and mutation detection.
  * Strengthened handoff validation for source paths containing special characters.
  * Prevented malformed handoff paths from causing validation failures or hangs.
  * Updated architecture scanning to ignore LangSmith experiment logs.

* **Security**
  * Pinned `brace-expansion` to a patched version to prevent excessive CPU consumption.

* **Release**
  * Updated the application to version `0.4.0-beta.8`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->