### PR TITLE
feat: add platform target option to init and update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to @rpamis/comet will be documented in this file.
 
+## What's Changed [0.4.0-beta.10] - 2026-07-26
+
+### Added
+
+- **Explicit platform targeting**: `comet init` and `comet update` now accept `--platform <platform>` to initialize or refresh one registered platform, or a project-scoped custom platform such as `.test`, while preserving workflow-scoped asset installation and the existing detection fallback when the option is omitted.
+
 ## What's Changed [0.4.0-beta.9] - 2026-07-25
 
 ### Added

--- a/README-zh.md
+++ b/README-zh.md
@@ -194,13 +194,14 @@ Comet Eval的自动化双Agent架构能够在线上与LangSmith/LangFuse环境�
 <details>
 <summary><code>comet init [path]</code> — 初始化 Comet 工作流</summary>
 
-为选定的 AI 编码平台初始化 Comet。交互模式可选择 Native、Classic 或两者；新的非交互项目默认使用自包含 Native，检测到既有 Classic 状态时保持 Classic。两套工作流拥有独立入口、状态、产物与 Guard；每个平台只安装一份 `comet-workflow-guard` Rule，支持 Hook 的平台只安装一个 `comet-hook-router.mjs`。Router 根据 `.comet/current-change.json`，一次只把写入路由给当前 Native 或 Classic Guard。只有 Classic 安装 OpenSpec 和 Superpowers，Native 不依赖外部 Skill。
+为选定的 AI 编码平台初始化 Comet。交互模式可选择 Native、Classic 或两者；新的非交互项目默认使用自包含 Native，检测到既有 Classic 状态时保持 Classic。传入 `--platform` 时只初始化该平台；未知但合法的平台 id 会作为项目内自定义平台安装到 `.<platform>/`，包含所选 workflow 的 skills、scripts、rules 与 hooks。两套工作流拥有独立入口、状态、产物与 Guard；每个平台只安装一份 `comet-workflow-guard` Rule，支持 Hook 的平台只安装一个 `comet-hook-router.mjs`。Router 根据 `.comet/current-change.json`，一次只把写入路由给当前 Native 或 Classic Guard。只有 Classic 安装 OpenSpec 和 Superpowers，Native 不依赖外部 Skill。
 
 | 选项                | 描述                                                 |
 | ------------------- | ---------------------------------------------------- |
 | `--yes`             | 非交互模式，自动选择已检测平台（未检测到则选择全部） |
 | `--scope <scope>`   | 安装范围：`project` 或 `global`                      |
 | `--language <lang>` | 技能语言：`en` 或 `zh`（跳过交互式语言选择）         |
+| `--platform <platform>` | 只初始化指定平台；项目范围内可使用自定义平台 id |
 | `--workflow <mode>` | 初始化工作流：`native`、`classic` 或 `both`          |
 | `--root <path>`     | Native 的项目内产物根目录，例如 `docs`               |
 | `--skip-existing`   | 跳过已安装的组件                                     |
@@ -267,12 +268,13 @@ Comet Eval的自动化双Agent架构能够在线上与LangSmith/LangFuse环境�
 <details>
 <summary><code>comet update [path]</code> — 更新 Comet 包和技能</summary>
 
-刷新已检测到的项目级/全局 Comet 技能。仅刷新当前项目时默认不会修改任何 npm 安装（包括全局包和项目级包）；需要同时升级 CLI 时必须显式传入 `--self-update`。显式 `--scope global` 会确定性走 current-project 资产范围，不会进入 all-projects 选择，也不会隐式更新 npm 包。自更新会先比较完整 semver（包括预发布版本），拒绝降级，并在安装前隔离验证候选包的版本、Workflow 与 Native 命令；安装失败时尝试恢复精确的当前版本。
+刷新已检测到的项目级/全局 Comet 技能；传入 `--platform` 时只刷新该平台，也可在项目范围内刷新自定义平台。仅刷新当前项目时默认不会修改任何 npm 安装（包括全局包和项目级包）；需要同时升级 CLI 时必须显式传入 `--self-update`。显式 `--scope global` 会确定性走 current-project 资产范围，不会进入 all-projects 选择，也不会隐式更新 npm 包。自更新会先比较完整 semver（包括预发布版本），拒绝降级，并在安装前隔离验证候选包的版本、Workflow 与 Native 命令；安装失败时尝试恢复精确的当前版本。
 
 | 选项                 | 描述                                      |
 | -------------------- | ----------------------------------------- |
 | `--json`             | 以 JSON 输出 npm 和 skill 更新结果        |
 | `--language <lang>`  | 覆盖自动检测到的 skill 语言 (`en`, `zh`)  |
+| `--platform <platform>` | 只刷新指定平台；项目范围内可使用自定义平台 id |
 | `--scope <scope>`    | 仅更新 `global` 或 `project` 安装范围     |
 | `--current-project`  | 只刷新当前项目                            |
 | `--all-projects`     | 刷新登记的所有项目级安装                  |

--- a/README.md
+++ b/README.md
@@ -212,13 +212,14 @@ Comet Eval's automated dual-agent architecture can integrate online with LangSmi
 <details>
 <summary><code>comet init [path]</code> — Initialize Comet workflow</summary>
 
-Initializes Comet for selected AI coding platforms. Interactive setup selects Native, Classic, or both; new non-interactive projects default to self-contained Native, while projects with existing Classic state remain Classic. The workflows keep independent entries, state, artifacts, and Guards. Each platform installs one `comet-workflow-guard` Rule, and platforms with Hook support install only `comet-hook-router.mjs`. The Router uses `.comet/current-change.json` to send each write to exactly one current Native or Classic Guard. Only Classic installs OpenSpec and Superpowers; Native depends on no external Skill.
+Initializes Comet for selected AI coding platforms. Interactive setup selects Native, Classic, or both; new non-interactive projects default to self-contained Native, while projects with existing Classic state remain Classic. Pass `--platform` to initialize only that platform; unknown but valid platform ids are treated as project-scoped custom platforms installed under `.<platform>/` with the selected workflow's skills, scripts, rules, and hooks. The workflows keep independent entries, state, artifacts, and Guards. Each platform installs one `comet-workflow-guard` Rule, and platforms with Hook support install only `comet-hook-router.mjs`. The Router uses `.comet/current-change.json` to send each write to exactly one current Native or Classic Guard. Only Classic installs OpenSpec and Superpowers; Native depends on no external Skill.
 
 | Option              | Description                                                                    |
 | ------------------- | ------------------------------------------------------------------------------ |
 | `--yes`             | Non-interactive mode, auto-select detected platforms (or all if none detected) |
 | `--scope <scope>`   | Install scope: `project` or `global`                                           |
 | `--language <lang>` | Skill language: `en` or `zh` (skips interactive language prompt)               |
+| `--platform <platform>` | Initialize only this platform; project scope accepts custom platform ids    |
 | `--workflow <mode>` | Workflows to initialize: `native`, `classic`, or `both`                        |
 | `--root <path>`     | Project-relative Native artifact root, such as `docs`                          |
 | `--skip-existing`   | Skip already installed components                                              |
@@ -286,12 +287,13 @@ for valid changes, and runtime evidence gaps that block safe resume.
 <details>
 <summary><code>comet update [path]</code> — Update Comet package and skills</summary>
 
-Refreshes installed Comet skills in detected project/global targets. A current-project refresh does not mutate any npm installation, whether global or project-local, by default; pass `--self-update` explicitly when the CLI should be upgraded too. Explicit `--scope global` deterministically uses the current-project asset scope, never opens the all-projects selector, and still does not update the npm package implicitly. Self-update compares full semver values, including prereleases, refuses downgrades, and validates the candidate package's version, Workflow command, and Native command in isolation before installation. A failed install attempts to restore the exact installed version.
+Refreshes installed Comet skills in detected project/global targets. Pass `--platform` to refresh only that platform, including project-scoped custom platforms. A current-project refresh does not mutate any npm installation, whether global or project-local, by default; pass `--self-update` explicitly when the CLI should be upgraded too. Explicit `--scope global` deterministically uses the current-project asset scope, never opens the all-projects selector, and still does not update the npm package implicitly. Self-update compares full semver values, including prereleases, refuses downgrades, and validates the candidate package's version, Workflow command, and Native command in isolation before installation. A failed install attempts to restore the exact installed version.
 
 | Option               | Description                                      |
 | -------------------- | ------------------------------------------------ |
 | `--json`             | Output npm and skill update results as JSON      |
 | `--language <lang>`  | Override detected skill language (`en`, `zh`)    |
+| `--platform <platform>` | Refresh only this platform; project scope accepts custom platform ids |
 | `--scope <scope>`    | Update only the `global` or `project` install scope |
 | `--current-project`  | Refresh only the current project                 |
 | `--all-projects`     | Refresh all registered project installations     |

--- a/app/cli/index.ts
+++ b/app/cli/index.ts
@@ -70,6 +70,7 @@ program
   .option('--skip-existing', 'Never overwrite existing components')
   .option('--overwrite', 'Overwrite manifest-managed files')
   .option('--json', 'Output as JSON')
+  .option('--platform <platform>', 'Platform target to initialize')
   .addOption(new Option('--scope <scope>', 'Install scope').choices(['global', 'project']))
   .addOption(new Option('--language <lang>', 'Language for skills').choices(['en', 'zh']))
   .addOption(
@@ -153,6 +154,7 @@ program
   .command('update [path]')
   .description('Update comet skill files to latest version')
   .option('--json', 'Output as JSON')
+  .option('--platform <platform>', 'Platform target to update')
   .addOption(new Option('--language <lang>', 'Language for skills').choices(['en', 'zh']))
   .addOption(new Option('--scope <scope>', 'Install scope').choices(['global', 'project']))
   .option('--all-projects', 'Update all indexed project-scope Comet installs')

--- a/app/commands/init.ts
+++ b/app/commands/init.ts
@@ -8,6 +8,10 @@ import {
   type Platform,
 } from '../../platform/install/platforms.js';
 import {
+  resolvePlatformTarget,
+  type PlatformTargetResolution,
+} from '../../platform/install/platform-targets.js';
+import {
   detectPlatforms,
   hasSkills,
   getBaseDir,
@@ -63,6 +67,7 @@ type InitOptions = {
   installMode?: InstallMode;
   workflow?: InitWorkflowSelection;
   artifactRoot?: string;
+  platform?: string;
 };
 
 function workflowChoiceNames(lang: string): Array<{
@@ -498,8 +503,14 @@ export async function initCommand(
   const installMode =
     workflowSelection === 'native' ? 'copy' : await selectInstallMode(options, lang);
 
-  const selectedPlatformIds = await selectPlatforms(detected, options, lang);
-  if (selectedPlatformIds.length === 0) {
+  const selectedPlatformTargets: PlatformTargetResolution[] = options.platform
+    ? [resolvePlatformTarget(options.platform, scope)]
+    : (await selectPlatforms(detected, options, lang)).map((platformId) => ({
+        platform: PLATFORMS.find((platform) => platform.id === platformId)!,
+        native: true,
+      }));
+  const selectedPlatformIds = selectedPlatformTargets.map((target) => target.platform.id);
+  if (selectedPlatformTargets.length === 0) {
     if (options.json) {
       console.log(
         JSON.stringify(
@@ -530,11 +541,12 @@ export async function initCommand(
     return { status: 'incomplete' };
   }
 
-  const selectedPlatforms = PLATFORMS.filter((p) => selectedPlatformIds.includes(p.id));
+  const selectedPlatforms = selectedPlatformTargets.map((target) => target.platform);
   const baseDir = getBaseDir(scope, projectPath);
 
   type PlatformPlan = ComponentPlan & {
     platform: Platform;
+    native: boolean;
     hasOS: boolean;
     hasSP: boolean;
     hasCM: boolean;
@@ -542,23 +554,28 @@ export async function initCommand(
 
   const plans: PlatformPlan[] = [];
 
-  for (const platform of selectedPlatforms) {
-    const hasOS = includesWorkflow(workflowSelection, 'classic')
-      ? await hasSkills(baseDir, platform, 'openspec', selectedPlatforms, scope)
-      : false;
-    const hasSP = includesWorkflow(workflowSelection, 'classic')
-      ? await hasSkills(baseDir, platform, 'superpowers', selectedPlatforms, scope)
-      : false;
+  for (const target of selectedPlatformTargets) {
+    const { platform, native } = target;
+    const hasOS =
+      native && includesWorkflow(workflowSelection, 'classic')
+        ? await hasSkills(baseDir, platform, 'openspec', selectedPlatforms, scope)
+        : false;
+    const hasSP =
+      native && includesWorkflow(workflowSelection, 'classic')
+        ? await hasSkills(baseDir, platform, 'superpowers', selectedPlatforms, scope)
+        : false;
     const hasCM = await hasSkills(baseDir, platform, 'comet', selectedPlatforms, scope, {
       includeGlobalFallback: false,
     });
 
-    let osAction = includesWorkflow(workflowSelection, 'classic')
-      ? resolveAction(hasOS, options)
-      : 'skip';
-    let spAction = includesWorkflow(workflowSelection, 'classic')
-      ? resolveAction(hasSP, options)
-      : 'skip';
+    let osAction =
+      native && includesWorkflow(workflowSelection, 'classic')
+        ? resolveAction(hasOS, options)
+        : 'skip';
+    let spAction =
+      native && includesWorkflow(workflowSelection, 'classic')
+        ? resolveAction(hasSP, options)
+        : 'skip';
     let cmAction =
       workflowSelection === 'classic'
         ? resolveCometAction(hasCM, options)
@@ -602,7 +619,7 @@ export async function initCommand(
       }
     }
 
-    plans.push({ platform, osAction, spAction, cmAction, hasOS, hasSP, hasCM });
+    plans.push({ platform, native, osAction, spAction, cmAction, hasOS, hasSP, hasCM });
   }
 
   if (includesWorkflow(workflowSelection, 'native') && scope === 'project') {
@@ -917,9 +934,6 @@ export async function initCommand(
         await installCometProjectInstructions(projectPath, language.id);
       }
 
-      const projectTargets = await detectInstalledCometTargets(projectPath, {
-        scopes: ['project'],
-      });
       const successfulCometPlatforms = new Set(
         results
           .filter(
@@ -931,9 +945,42 @@ export async function initCommand(
           )
           .map((result) => result.platform.id),
       );
-      const completeProjectTargets = projectTargets.filter((target) =>
-        successfulCometPlatforms.has(target.platform.id),
-      );
+      const completeProjectTargets = options.platform
+        ? (
+            await Promise.all(
+              plans
+                .filter(
+                  (plan) =>
+                    plan.cmAction !== 'skip' && successfulCometPlatforms.has(plan.platform.id),
+                )
+                .map(async (plan) => {
+                  if (plan.cmAction !== 'reuse') {
+                    return {
+                      platform: plan.platform,
+                      language: language.id,
+                    };
+                  }
+                  const existing = (
+                    await detectInstalledCometTargets(projectPath, {
+                      scopes: ['project'],
+                    })
+                  ).find((target) => target.platform.id === plan.platform.id);
+                  return existing
+                    ? {
+                        platform: plan.platform,
+                        language: existing.language,
+                      }
+                    : null;
+                }),
+            )
+          ).filter((target): target is { platform: Platform; language: 'en' | 'zh' } =>
+            Boolean(target),
+          )
+        : (
+            await detectInstalledCometTargets(projectPath, {
+              scopes: ['project'],
+            })
+          ).filter((target) => successfulCometPlatforms.has(target.platform.id));
       if (completeProjectTargets.length > 0) {
         await upsertProjectInstallation(
           projectPath,

--- a/app/commands/update.ts
+++ b/app/commands/update.ts
@@ -16,12 +16,17 @@ import {
 } from '../../domains/skill/platform-install.js';
 import { removeLegacyCometSkillsForPlatform } from '../../domains/skill/uninstall.js';
 import { installCometProjectInstructions } from '../../domains/skill/project-instructions.js';
-import { LANGUAGES } from '../../domains/skill/languages.js';
+import {
+  artifactLanguageToSkillLanguage,
+  LANGUAGES,
+  type SkillLanguageId,
+} from '../../domains/skill/languages.js';
 import {
   getPlatformSkillsDir,
   getPlatformSkillsDirs,
   type Platform,
 } from '../../platform/install/platforms.js';
+import { resolvePlatformTarget } from '../../platform/install/platform-targets.js';
 import { resolveCanonicalSkillRootOwners } from '../../platform/install/skill-root-owner.js';
 import {
   listProjectRegistryEntries,
@@ -62,9 +67,10 @@ interface UpdateOptions {
   failOnNpmFailure?: boolean;
   npmSkipReason?: string;
   skipPackageSelfUpdate?: boolean;
+  platform?: string;
 }
 
-type SkillLanguage = 'en' | 'zh';
+type SkillLanguage = SkillLanguageId;
 type NpmStatus = 'updated' | 'failed' | 'skipped';
 type CodegraphStatus = 'installed' | 'failed' | 'skipped';
 
@@ -1228,10 +1234,34 @@ async function updateSingleProject(
     }
   }
 
-  const targets = await detectInstalledCometTargets(projectPath, {
-    scopes: options.targetScopes ?? (options.scope ? [options.scope] : undefined),
-    respectDetectionPaths: options.scope === undefined,
-  });
+  const targets = options.platform
+    ? await Promise.all(
+        (options.targetScopes ?? [options.scope ?? 'project']).map(async (scope) => {
+          const existing = options.language
+            ? null
+            : (
+                await detectInstalledCometTargets(projectPath, {
+                  scopes: [scope],
+                  respectDetectionPaths: scope === 'project' && options.scope === undefined,
+                })
+              ).find((candidate) => candidate.platform.id === options.platform);
+          const fallbackLanguage =
+            existing?.language ??
+            (scope === 'project'
+              ? artifactLanguageToSkillLanguage(projectConfig?.native.language)
+              : 'en');
+          const target = resolvePlatformTarget(options.platform!, scope);
+          return {
+            scope,
+            platform: target.platform,
+            language: resolveTargetLanguage(options.language, fallbackLanguage),
+          };
+        }),
+      )
+    : await detectInstalledCometTargets(projectPath, {
+        scopes: options.targetScopes ?? (options.scope ? [options.scope] : undefined),
+        respectDetectionPaths: options.scope === undefined,
+      });
 
   if (targets.length === 0) {
     return {
@@ -1864,6 +1894,9 @@ export async function updateCommand(
   const lang = options.language ?? 'en';
 
   assertProjectScopeOptions(options);
+  if (options.platform && options.allProjects) {
+    throw new Error('--platform cannot be combined with --all-projects');
+  }
   const registryProjects = await listProjectRegistryEntries({ strict: true });
 
   log(`\n  ${t(lang, 'updateTitle')}`);

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0-beta.9",
+  "version": "0.4.0-beta.10",
   "skills": [
     "comet/SKILL.md",
     "comet-classic/SKILL.md",

--- a/domains/skill/languages.ts
+++ b/domains/skill/languages.ts
@@ -38,5 +38,17 @@ function resolveArtifactLanguage(language: string | undefined): ArtifactLanguage
   return match;
 }
 
-export { ARTIFACT_LANGUAGES, LANGUAGES, resolveArtifactLanguage, formatSupportedArtifactLanguages };
+function artifactLanguageToSkillLanguage(
+  language: ArtifactLanguageId | undefined,
+): SkillLanguageId {
+  return language === 'zh-CN' ? 'zh' : 'en';
+}
+
+export {
+  ARTIFACT_LANGUAGES,
+  LANGUAGES,
+  artifactLanguageToSkillLanguage,
+  resolveArtifactLanguage,
+  formatSupportedArtifactLanguages,
+};
 export type { ArtifactLanguageId, ArtifactLanguageConfig, LanguageConfig, SkillLanguageId };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rpamis/comet",
-  "version": "0.4.0-beta.9",
+  "version": "0.4.0-beta.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rpamis/comet",
-      "version": "0.4.0-beta.9",
+      "version": "0.4.0-beta.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rpamis/comet",
-  "version": "0.4.0-beta.9",
+  "version": "0.4.0-beta.10",
   "description": "Agent Skill Harness For Turning Ideas Into Evaluated Workflows",
   "keywords": [
     "comet",

--- a/platform/install/platform-targets.ts
+++ b/platform/install/platform-targets.ts
@@ -1,0 +1,43 @@
+import { isValidPlatformId, PLATFORMS, type Platform } from './platforms.js';
+import type { InstallScope } from './types.js';
+
+export type PlatformTargetResolution = {
+  platform: Platform;
+  native: boolean;
+};
+
+export function resolvePlatformTarget(
+  platformId: string,
+  scope: InstallScope,
+): PlatformTargetResolution {
+  const normalized = platformId.trim();
+  if (normalized.length === 0) {
+    throw new Error('--platform must be a non-empty platform id');
+  }
+  if (!isValidPlatformId(normalized)) {
+    throw new Error('--platform must contain only lowercase letters, numbers, and hyphens');
+  }
+
+  const registered = PLATFORMS.find((platform) => platform.id === normalized);
+  if (registered) {
+    return { platform: registered, native: true };
+  }
+
+  if (scope === 'global') {
+    throw new Error('custom --platform targets are only supported with project scope');
+  }
+
+  return {
+    platform: {
+      id: normalized,
+      name: normalized,
+      skillsDir: `.${normalized}`,
+      openspecToolId: normalized,
+      rulesDir: 'rules',
+      rulesFormat: 'md',
+      supportsHooks: true,
+      hookFormat: 'claude-code',
+    },
+    native: false,
+  };
+}

--- a/platform/install/platforms.ts
+++ b/platform/install/platforms.ts
@@ -41,6 +41,12 @@ export interface Platform {
   legacyHookConfigFiles?: string[];
 }
 
+const PLATFORM_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
+
+export function isValidPlatformId(platformId: string): boolean {
+  return PLATFORM_ID_PATTERN.test(platformId);
+}
+
 export function getPlatformSkillsDir(platform: Platform, scope: InstallScope): string {
   if (scope === 'global' && platform.globalSkillsDir) {
     return platform.globalSkillsDir;

--- a/test/app/cli-help.test.ts
+++ b/test/app/cli-help.test.ts
@@ -24,21 +24,12 @@ describe('CLI help text', () => {
     const packageJson = JSON.parse(
       readFileSync(path.join(repositoryRoot, 'package.json'), 'utf8'),
     ) as { description: string; version: string };
-    const packageLock = JSON.parse(
-      readFileSync(path.join(repositoryRoot, 'package-lock.json'), 'utf8'),
-    ) as { version: string; packages: { '': { version: string } } };
-    const assetsManifest = JSON.parse(
-      readFileSync(path.join(repositoryRoot, 'assets', 'manifest.json'), 'utf8'),
-    ) as { version: string };
     const tagline = 'Agent Skill Harness For Turning Ideas Into Evaluated Workflows';
 
     expect(help.status, help.stderr).toBe(0);
     expect(help.stdout).toContain(tagline);
     expect(packageJson.description).toBe(tagline);
-    expect(packageJson.version).toBe('0.4.0-beta.9');
-    expect(packageLock.version).toBe('0.4.0-beta.9');
-    expect(packageLock.packages[''].version).toBe('0.4.0-beta.9');
-    expect(assetsManifest.version).toBe('0.4.0-beta.9');
+    expect(packageJson.version).toBe('0.4.0-beta.10');
   });
 
   it('marks bundle as the advanced backend and skill Engine runs as advanced', () => {
@@ -136,13 +127,21 @@ describe('CLI help text', () => {
     expect(help.stdout).not.toContain('eval [options]');
   });
 
-  it('exposes explicit package self-update controls', () => {
+  it('exposes explicit update target controls', () => {
     const help = runCli('update', '--help');
 
     expect(help.status, help.stderr).toBe(0);
     expect(help.stdout).toContain('--self-update');
     expect(help.stdout).toContain('--skip-self-update');
+    expect(help.stdout).toContain('--platform <platform>');
     expect(help.stdout).not.toContain('--skip-npm');
+  });
+
+  it('exposes explicit init target controls', () => {
+    const help = runCli('init', '--help');
+
+    expect(help.status, help.stderr).toBe(0);
+    expect(help.stdout).toContain('--platform <platform>');
   });
 
   it('keeps Skill Creator resume commands out of the publish surface', () => {

--- a/test/app/init-e2e.test.ts
+++ b/test/app/init-e2e.test.ts
@@ -655,6 +655,108 @@ describe('comet init E2E', () => {
     expect(platformSelectPrompt).not.toHaveBeenCalled();
   });
 
+  it('initializes only the explicit native platform target', async () => {
+    mockExternalSuccess();
+    const { platformSelectPrompt } = await import('../../app/commands/platform-select-prompt.js');
+    const { initCommand } = await import('../../app/commands/init.js');
+
+    const result = await captureJsonOutput(() =>
+      initCommand(tmpDir, {
+        yes: true,
+        json: true,
+        platform: 'codex',
+      }),
+    );
+
+    expect(result).toMatchObject({
+      status: 'complete',
+      selectedPlatforms: ['codex'],
+      results: [expect.objectContaining({ platform: 'codex', comet: 'installed' })],
+    });
+    expect(platformSelectPrompt).not.toHaveBeenCalled();
+    await expect(
+      fs.access(path.join(tmpDir, '.agents', 'skills', 'comet', 'SKILL.md')),
+    ).resolves.toBeUndefined();
+    await expect(
+      fs.access(path.join(tmpDir, '.claude', 'skills', 'comet', 'SKILL.md')),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('initializes project-scoped custom platform workflow assets', async () => {
+    mockExternalSuccess();
+    const { initCommand } = await import('../../app/commands/init.js');
+
+    const result = await captureJsonOutput(() =>
+      initCommand(tmpDir, {
+        yes: true,
+        json: true,
+        platform: 'test',
+      }),
+    );
+
+    expect(result).toMatchObject({
+      status: 'complete',
+      selectedPlatforms: ['test'],
+      results: [expect.objectContaining({ platform: 'test', comet: 'installed' })],
+    });
+    await expect(
+      fs.access(path.join(tmpDir, '.test', 'skills', 'comet', 'SKILL.md')),
+    ).resolves.toBeUndefined();
+    await expect(
+      fs.access(path.join(tmpDir, '.test', 'skills', 'comet', 'scripts', 'comet-hook-router.mjs')),
+    ).resolves.toBeUndefined();
+    await expect(
+      fs.access(path.join(tmpDir, '.test', 'rules', 'comet-workflow-guard.md')),
+    ).resolves.toBeUndefined();
+    const settings = JSON.parse(
+      await fs.readFile(path.join(tmpDir, '.test', 'settings.local.json'), 'utf8'),
+    ) as { hooks: { PreToolUse: Array<{ hooks: Array<{ command: string }> }> } };
+    expect(JSON.stringify(settings.hooks)).toContain('comet-hook-router.mjs');
+  });
+
+  it('applies workflow selection to an explicit custom platform target', async () => {
+    mockExternalSuccess();
+    const manifest = await readManifest();
+    const { initCommand } = await import('../../app/commands/init.js');
+
+    const result = await captureJsonOutput(() =>
+      initCommand(tmpDir, {
+        yes: true,
+        json: true,
+        platform: 'test',
+        workflow: 'native',
+      }),
+    );
+
+    expect(result).toMatchObject({ status: 'complete', selectedPlatforms: ['test'] });
+    for (const skillPath of skillPathsForWorkflow(manifest, 'native')) {
+      await expect(
+        fs.access(path.join(tmpDir, '.test', 'skills', skillPath)),
+      ).resolves.toBeUndefined();
+    }
+    const excludedPaths = manifest.skills.filter(
+      (skillPath: string) => !skillPathsForWorkflow(manifest, 'native').includes(skillPath),
+    );
+    for (const skillPath of excludedPaths) {
+      await expect(
+        fs.access(path.join(tmpDir, '.test', 'skills', skillPath)),
+      ).rejects.toMatchObject({ code: 'ENOENT' });
+    }
+  });
+
+  it('rejects custom platform targets for global init', async () => {
+    const { initCommand } = await import('../../app/commands/init.js');
+
+    await expect(
+      initCommand(tmpDir, {
+        yes: true,
+        json: true,
+        scope: 'global',
+        platform: 'test',
+      }),
+    ).rejects.toThrow('custom --platform targets are only supported with project scope');
+  });
+
   it('rejects project artifact roots at global scope without writes', async () => {
     mockExternalSuccess();
     await fs.mkdir(path.join(tmpDir, '.claude'), { recursive: true });
@@ -1251,6 +1353,40 @@ describe('comet init E2E', () => {
       lastSource: 'init',
     });
     expect(registry.projects[0].lastTargets.length).toBeGreaterThan(0);
+  });
+
+  it('preserves the installed language when reusing an explicit project target', async () => {
+    mockExternalSuccess();
+    const fakeHome = path.join(tmpDir, 'fake-home-explicit-reuse-language');
+    await fs.mkdir(path.join(tmpDir, '.agents', 'skills', 'comet'), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, '.agents', 'skills', 'comet', 'SKILL.md'),
+      '# Comet\n\n当用户提出需求时使用这个技能。',
+      'utf-8',
+    );
+    const homedirSpy = vi.spyOn(os, 'homedir').mockReturnValue(fakeHome);
+
+    try {
+      const { initCommand } = await import('../../app/commands/init.js');
+      await captureJsonOutput(() =>
+        initCommand(tmpDir, {
+          yes: true,
+          scope: 'project',
+          json: true,
+          workflow: 'classic',
+          platform: 'codex',
+          language: 'en',
+        }),
+      );
+    } finally {
+      homedirSpy.mockRestore();
+    }
+
+    const registry = JSON.parse(await fs.readFile(getProjectRegistryPath(fakeHome), 'utf-8'));
+    expect(registry.projects[0].lastTargets).toContainEqual({
+      platform: 'codex',
+      language: 'zh',
+    });
   });
 
   it('does not record global-scope installs in the user project registry', async () => {

--- a/test/app/update.test.ts
+++ b/test/app/update.test.ts
@@ -64,6 +64,12 @@ const claudePlatform: Platform = {
   openspecToolId: 'claude',
 };
 
+const manifestPath = path.resolve('assets', 'manifest.json');
+
+async function readManifest() {
+  return JSON.parse(await fs.readFile(manifestPath, 'utf-8')) as { skills: string[] };
+}
+
 type ComponentFailure = 'Skill' | 'Rule' | 'Hook';
 
 async function writeFakeCometPackage(packageRoot: string, version: string): Promise<void> {
@@ -1757,6 +1763,123 @@ describe('update command helpers', () => {
     expect(registry.projects[0].lastSource).toBe('update');
   });
 
+  it('updates only the explicit native platform target', async () => {
+    const fakeHome = path.join(tmpDir, 'explicit-native-home');
+    await fs.mkdir(path.join(tmpDir, '.claude', 'skills', 'comet'), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, '.claude', 'skills', 'comet', 'SKILL.md'),
+      '# Stale Claude Comet\n',
+      'utf8',
+    );
+
+    const homeSpy = vi.spyOn(os, 'homedir').mockReturnValue(fakeHome);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    let json: string;
+    try {
+      await updateCommand(tmpDir, {
+        json: true,
+        skipNpm: true,
+        platform: 'codex',
+      });
+      json = log.mock.calls.map((call) => call.join(' ')).join('\n');
+    } finally {
+      log.mockRestore();
+      homeSpy.mockRestore();
+    }
+
+    const result = JSON.parse(json);
+    expect(result.skills.targets).toEqual([
+      expect.objectContaining({ scope: 'project', platform: 'codex' }),
+    ]);
+    await expect(
+      fs.readFile(path.join(tmpDir, '.agents', 'skills', 'comet', 'SKILL.md'), 'utf8'),
+    ).resolves.toContain('comet workflow resolve . --json');
+    await expect(
+      fs.readFile(path.join(tmpDir, '.claude', 'skills', 'comet', 'SKILL.md'), 'utf8'),
+    ).resolves.toBe('# Stale Claude Comet\n');
+  });
+
+  it('updates project-scoped custom platform workflow assets', async () => {
+    const fakeHome = path.join(tmpDir, 'explicit-custom-home');
+    const homeSpy = vi.spyOn(os, 'homedir').mockReturnValue(fakeHome);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    let json: string;
+    try {
+      await updateCommand(tmpDir, {
+        json: true,
+        skipNpm: true,
+        platform: 'test',
+      });
+      json = log.mock.calls.map((call) => call.join(' ')).join('\n');
+    } finally {
+      log.mockRestore();
+      homeSpy.mockRestore();
+    }
+
+    const result = JSON.parse(json);
+    expect(result.skills.targets).toEqual([
+      expect.objectContaining({ scope: 'project', platform: 'test' }),
+    ]);
+    await expect(
+      fs.access(path.join(tmpDir, '.test', 'skills', 'comet', 'SKILL.md')),
+    ).resolves.toBeUndefined();
+    await expect(
+      fs.access(path.join(tmpDir, '.test', 'skills', 'comet', 'scripts', 'comet-hook-router.mjs')),
+    ).resolves.toBeUndefined();
+    await expect(
+      fs.access(path.join(tmpDir, '.test', 'rules', 'comet-workflow-guard.md')),
+    ).resolves.toBeUndefined();
+    const settings = JSON.parse(
+      await fs.readFile(path.join(tmpDir, '.test', 'settings.local.json'), 'utf8'),
+    ) as { hooks: { PreToolUse: Array<{ hooks: Array<{ command: string }> }> } };
+    expect(JSON.stringify(settings.hooks)).toContain('comet-hook-router.mjs');
+  });
+
+  it('applies the project workflow selection to an explicit custom update target', async () => {
+    const fakeHome = path.join(tmpDir, 'explicit-custom-both-home');
+    const config = defaultProjectConfig('docs');
+    config.workflows = ['native', 'classic'];
+    config.default_workflow = 'native';
+    await writeProjectConfig(tmpDir, config);
+
+    const homeSpy = vi.spyOn(os, 'homedir').mockReturnValue(fakeHome);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    let json: string;
+    try {
+      await updateCommand(tmpDir, {
+        json: true,
+        skipNpm: true,
+        platform: 'test',
+      });
+      json = log.mock.calls.map((call) => call.join(' ')).join('\n');
+    } finally {
+      log.mockRestore();
+      homeSpy.mockRestore();
+    }
+
+    const result = JSON.parse(json);
+    expect(result.skills.targets).toEqual([
+      expect.objectContaining({ scope: 'project', platform: 'test' }),
+    ]);
+    const manifest = await readManifest();
+    for (const skillPath of manifest.skills) {
+      await expect(
+        fs.access(path.join(tmpDir, '.test', 'skills', skillPath)),
+      ).resolves.toBeUndefined();
+    }
+  });
+
+  it('rejects custom platform targets for global update', async () => {
+    await expect(
+      updateCommand(tmpDir, {
+        json: true,
+        skipNpm: true,
+        scope: 'global',
+        platform: 'test',
+      }),
+    ).rejects.toThrow('custom --platform targets are only supported with project scope');
+  });
+
   it('returns stable JSON summary when no installed targets are found', async () => {
     const fakeHome = path.join(tmpDir, 'fake-home-instructions');
     const homedirSpy = vi.spyOn(os, 'homedir').mockReturnValue(fakeHome);
@@ -2364,6 +2487,39 @@ describe('update command helpers', () => {
     const config = await fs.readFile(path.join(fakeHome, '.comet', 'config.yaml'), 'utf-8');
     expect(config).toContain('language: zh-CN');
     await expect(fs.stat(path.join(fakeHome, 'docs', 'superpowers'))).rejects.toThrow();
+  });
+
+  it('preserves installed language for an explicit global platform update', async () => {
+    const fakeHome = path.join(tmpDir, 'fake-home-explicit-global-language');
+    await fs.mkdir(path.join(fakeHome, '.codex', 'skills', 'comet'), { recursive: true });
+    await fs.writeFile(
+      path.join(fakeHome, '.codex', 'skills', 'comet', 'SKILL.md'),
+      '# Comet\n\n当用户提出需求时使用这个技能。',
+      'utf-8',
+    );
+    const homeSpy = vi.spyOn(os, 'homedir').mockReturnValue(fakeHome);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    let json: string;
+
+    try {
+      await updateCommand(tmpDir, {
+        json: true,
+        skipNpm: true,
+        scope: 'global',
+        platform: 'codex',
+      });
+      json = log.mock.calls.map((call) => call.join(' ')).join('\n');
+    } finally {
+      log.mockRestore();
+      homeSpy.mockRestore();
+    }
+
+    const result = JSON.parse(json);
+    expect(result.skills.targets).toEqual([
+      expect.objectContaining({ scope: 'global', platform: 'codex', language: 'zh' }),
+    ]);
+    const config = await fs.readFile(path.join(fakeHome, '.comet', 'config.yaml'), 'utf-8');
+    expect(config).toContain('language: zh-CN');
   });
 
   it('re-persists an explicitly requested language even when the config already has a different one', async () => {

--- a/test/domains/comet-native/native-lock-concurrency.test.ts
+++ b/test/domains/comet-native/native-lock-concurrency.test.ts
@@ -34,6 +34,20 @@ async function waitFor(file: string): Promise<void> {
   throw new Error(`Timed out waiting for ${file}`);
 }
 
+async function waitForText(file: string): Promise<string> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    try {
+      const text = await fs.readFile(file, 'utf8');
+      if (text.length > 0) return text;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(`Timed out waiting for content in ${file}`);
+}
+
 function collect(child: ChildProcessWithoutNullStreams): Promise<WorkerResult> {
   let stdout = '';
   let stderr = '';
@@ -173,8 +187,7 @@ describe('Native lock process concurrency', () => {
     await waitFor(ready);
     await fs.writeFile(`${go}.primary`, 'replacement-ready\n');
     await fs.writeFile(go, 'go\n');
-    await waitFor(status);
-    expect(await fs.readFile(status, 'utf8')).toMatch(/^blocked:/u);
+    await expect(waitForText(status)).resolves.toMatch(/^blocked:/u);
     expect(await fs.readFile(replacement.file, 'utf8')).toContain(replacement.owner.id);
     await expect(workerProcess.result).resolves.toMatchObject({ code: 0, stderr: '' });
     await releaseNativeLock(replacement);
@@ -194,11 +207,7 @@ describe('Native lock process concurrency', () => {
 
     await Promise.all([waitFor(readyA), waitFor(readyB)]);
     await fs.writeFile(go, 'go\n');
-    await Promise.all([waitFor(statusA), waitFor(statusB)]);
-    const statuses = await Promise.all([
-      fs.readFile(statusA, 'utf8'),
-      fs.readFile(statusB, 'utf8'),
-    ]);
+    const statuses = await Promise.all([waitForText(statusA), waitForText(statusB)]);
     expect(statuses.filter((status) => status.startsWith('acquired:'))).toHaveLength(1);
     expect(statuses.filter((status) => status.startsWith('blocked:'))).toHaveLength(1);
     expect(statuses.join('\n')).not.toContain('coordinator is busy');

--- a/test/domains/skill/skills.test.ts
+++ b/test/domains/skill/skills.test.ts
@@ -36,7 +36,10 @@ import {
   mergeProjectConfig,
 } from '../../../domains/skill/platform-install.js';
 import { PLATFORMS, type Platform } from '../../../platform/install/platforms.js';
-import { resolveArtifactLanguage } from '../../../domains/skill/languages.js';
+import {
+  artifactLanguageToSkillLanguage,
+  resolveArtifactLanguage,
+} from '../../../domains/skill/languages.js';
 
 describe('skills', () => {
   let tmpDir: string;
@@ -89,6 +92,12 @@ describe('skills', () => {
     it('rejects zh and en-US as artifact language values', () => {
       expect(() => resolveArtifactLanguage('zh')).toThrow('Invalid artifact language');
       expect(() => resolveArtifactLanguage('en-US')).toThrow('Invalid artifact language');
+    });
+
+    it('maps persisted artifact languages to skill language ids', () => {
+      expect(artifactLanguageToSkillLanguage('zh-CN')).toBe('zh');
+      expect(artifactLanguageToSkillLanguage('en')).toBe('en');
+      expect(artifactLanguageToSkillLanguage(undefined)).toBe('en');
     });
 
     it('does not route Comet artifact language through the current user request language', async () => {

--- a/test/platform/platform-targets.test.ts
+++ b/test/platform/platform-targets.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { PLATFORMS } from '../../platform/install/platforms.js';
+import { resolvePlatformTarget } from '../../platform/install/platform-targets.js';
+
+describe('resolvePlatformTarget', () => {
+  it('returns a registered native platform by id', () => {
+    const codex = PLATFORMS.find((platform) => platform.id === 'codex')!;
+
+    expect(resolvePlatformTarget('codex', 'project')).toEqual({
+      platform: codex,
+      native: true,
+    });
+  });
+
+  it('creates a conservative project-scoped custom platform', () => {
+    expect(resolvePlatformTarget('test', 'project')).toEqual({
+      native: false,
+      platform: {
+        id: 'test',
+        name: 'test',
+        skillsDir: '.test',
+        openspecToolId: 'test',
+        rulesDir: 'rules',
+        rulesFormat: 'md',
+        supportsHooks: true,
+        hookFormat: 'claude-code',
+      },
+    });
+  });
+
+  it.each(['', '   '])('rejects empty platform id %#', (platformId) => {
+    expect(() => resolvePlatformTarget(platformId, 'project')).toThrow(
+      '--platform must be a non-empty platform id',
+    );
+  });
+
+  it.each(['Codex', 'codex_cli', 'codex.cli', 'codex/cli'])(
+    'rejects malformed platform id %s',
+    (platformId) => {
+      expect(() => resolvePlatformTarget(platformId, 'project')).toThrow(
+        '--platform must contain only lowercase letters, numbers, and hyphens',
+      );
+    },
+  );
+
+  it('rejects global custom platform targets', () => {
+    expect(() => resolvePlatformTarget('test', 'global')).toThrow(
+      'custom --platform targets are only supported with project scope',
+    );
+  });
+});

--- a/test/repository/release-metadata.test.ts
+++ b/test/repository/release-metadata.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+const repositoryRoot = path.resolve('.');
+
+describe('release metadata', () => {
+  it('keeps package, lockfile, and asset manifest versions aligned', () => {
+    const packageJson = JSON.parse(
+      readFileSync(path.join(repositoryRoot, 'package.json'), 'utf8'),
+    ) as { version: string };
+    const packageLock = JSON.parse(
+      readFileSync(path.join(repositoryRoot, 'package-lock.json'), 'utf8'),
+    ) as { version: string; packages: { '': { version: string } } };
+    const assetsManifest = JSON.parse(
+      readFileSync(path.join(repositoryRoot, 'assets', 'manifest.json'), 'utf8'),
+    ) as { version: string };
+
+    expect(packageJson.version).toBe('0.4.0-beta.10');
+    expect(packageLock.version).toBe(packageJson.version);
+    expect(packageLock.packages[''].version).toBe(packageJson.version);
+    expect(assetsManifest.version).toBe(packageJson.version);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `--platform <platform>` to `comet init` and `comet update`.
- Support registered platforms and project-scoped custom platform ids.
- Update README, changelog, version metadata, and tests.

## Test Plan
- `npx vitest run test/platform/platform-targets.test.ts test/app/init-e2e.test.ts test/app/update.test.ts test/app/cli-help.test.ts`
- `pnpm format:check`
- `pnpm lint`
- `pnpm build`
- `git diff --check`
- `env GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false npx vitest run test/domains/comet-classic/comet-scripts.test.ts`
- `npx prettier --check README.md README-zh.md`
- `npx vitest run test/repository/readme.test.ts test/app/cli-help.test.ts`

## Notes
Full `npx vitest run` was re-run with local git signing disabled. It still has two unrelated existing Native file identity test failures:
- `test/domains/comet-native/native-check-receipt.test.ts`
- `test/domains/comet-native/native-snapshot.test.ts`

## Summary by Sourcery

Add explicit platform targeting to comet init and update, supporting single-platform and project-scoped custom installations while keeping existing workflow and detection behavior, and tighten npm CLI discovery and release metadata.

New Features:
- Add a --platform <platform> option to comet init to initialize only a specific registered or project-scoped custom platform.
- Add a --platform <platform> option to comet update to refresh only a specific registered or project-scoped custom platform.
- Introduce shared platform target resolution that validates platform ids, maps registered platforms, and constructs project-scoped custom platform definitions.

Bug Fixes:
- Harden npm CLI discovery for self-update to skip invalid PATH candidates such as non-directory entries, preventing resolution errors.

Enhancements:
- Integrate explicit platform targets into init and update workflows while preserving native/classic asset filtering and existing detection fallbacks.
- Extend JSON summaries for init and update to reflect explicit platform targets and workflow-scoped asset installation.
- Add validation to reject custom platform targets at global scope and incompatible combinations like --platform with --all-projects.

Build:
- Bump package and assets manifest versions to 0.4.0-beta.9 to reflect the new release.

Documentation:
- Document the new --platform option for comet init and comet update in both English and Chinese READMEs, including custom project-scoped platform behavior.
- Add internal design and implementation plan documents for platform target selection.

Tests:
- Add unit tests for platform target resolution covering registered, custom, and invalid platform ids and scope constraints.
- Extend init and update E2E tests to cover explicit native and custom platform targets, workflow-aware asset installation, global-scope rejection, and CLI help text for the new option.
- Update CLI help tests to verify exposure of explicit init and update target controls and bump version expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--platform <platform>` to `comet init` and `comet update` to initialize/refresh a specific platform, including project-scoped custom platforms.
  * `comet update` now requires `--self-update` to upgrade the CLI; platform-scoped updates leave non-selected assets unchanged.
* **Bug Fixes**
  * Improved update behavior for platform/language handling, deterministic `--scope global` asset coverage, and safer self-update checks with rollback on install failure.
* **Documentation**
  * Updated `README.md` and `README-zh.md` to document `--platform` behavior for init/update.
* **Tests**
  * Added/extended E2E and unit tests for explicit platform targets, validation/error cases, and language-mapping constraints; added version-alignment release-metadata test.
* **Release**
  * Bumped version to `0.4.0-beta.9` (including manifest).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->