### PR TITLE
fix: add environment fallback to get_dockerfile_hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to @rpamis/comet will be documented in this file.
 
+## What's Changed [0.4.0-beta.15] - 2026-08-02
+
+### Fixed
+
+- **Eval Dockerfile hash fallback**: `get_dockerfile_hash()` now falls back to `environment/Dockerfile` when a workspace has no root `Dockerfile`, matching the fallback `docker_build()` already applied. Building or naming an image for an eval workspace that keeps its Dockerfile under `environment/` no longer fails before reaching Docker.
+
 ## What's Changed [0.4.0-beta.14] - 2026-08-02
 
 ### Fixed

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0-beta.14",
+  "version": "0.4.0-beta.15",
   "skills": [
     "comet/SKILL.md",
     "comet-classic/SKILL.md",

--- a/eval/local/tests/scaffold/test_utils.py
+++ b/eval/local/tests/scaffold/test_utils.py
@@ -6,6 +6,7 @@ import subprocess
 from pathlib import Path
 
 import dotenv
+import pytest
 
 from scaffold.python import utils
 from scaffold.python.skill_parser import load_skill_content, parse_skill_md
@@ -215,6 +216,45 @@ def test_docker_harness_has_no_native_review_sidecar_contract():
     assert "native_review_sidecar" not in docker_sh
     assert "NATIVE_REVIEW_CONTROLLER_VOLUME" not in docker_sh
     assert "COMET_NATIVE_REVIEW_VERIFIER_URL" not in docker_sh
+
+
+def test_get_image_name_falls_back_to_environment_dockerfile(tmp_path: Path):
+    """get_image_name() resolves environment/Dockerfile when dir/Dockerfile is absent.
+
+    docker_build() falls back to environment/Dockerfile, so get_image_name() must
+    apply the same rule; otherwise the fallback in docker_build() is dead code and
+    building a workspace that only carries an environment/Dockerfile always fails.
+    """
+    env_dir = tmp_path / "environment"
+    env_dir.mkdir()
+    (env_dir / "Dockerfile").write_text("FROM python:3.11-slim\n", encoding="utf-8")
+
+    script = (
+        'source "$1"; '
+        'image=$(get_image_name "$2") || { echo "image lookup failed"; exit 1; }; '
+        'echo "image=$image"'
+    )
+    try:
+        result = subprocess.run(
+            [
+                utils.BASH_EXEC,
+                "-c",
+                script,
+                "_",
+                utils._to_bash_path(utils.SHELL_DIR / "docker.sh"),
+                utils._to_bash_path(tmp_path),
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+    except FileNotFoundError:
+        pytest.skip("bash not available")
+
+    assert result.returncode == 0, f"get_image_name failed (stderr: {result.stderr})"
+    assert "image=skillbench:" in result.stdout
 
 
 def test_run_claude_fixture_defaults_langsmith_hook_log_path():

--- a/eval/local/tests/scaffold/test_utils.py
+++ b/eval/local/tests/scaffold/test_utils.py
@@ -218,17 +218,8 @@ def test_docker_harness_has_no_native_review_sidecar_contract():
     assert "COMET_NATIVE_REVIEW_VERIFIER_URL" not in docker_sh
 
 
-def test_get_image_name_falls_back_to_environment_dockerfile(tmp_path: Path):
-    """get_image_name() resolves environment/Dockerfile when dir/Dockerfile is absent.
-
-    docker_build() falls back to environment/Dockerfile, so get_image_name() must
-    apply the same rule; otherwise the fallback in docker_build() is dead code and
-    building a workspace that only carries an environment/Dockerfile always fails.
-    """
-    env_dir = tmp_path / "environment"
-    env_dir.mkdir()
-    (env_dir / "Dockerfile").write_text("FROM python:3.11-slim\n", encoding="utf-8")
-
+def _get_image_name(directory: Path) -> str:
+    """Resolve the image name for a workspace directory via docker.sh (bash required)."""
     script = (
         'source "$1"; '
         'image=$(get_image_name "$2") || { echo "image lookup failed"; exit 1; }; '
@@ -242,7 +233,7 @@ def test_get_image_name_falls_back_to_environment_dockerfile(tmp_path: Path):
                 script,
                 "_",
                 utils._to_bash_path(utils.SHELL_DIR / "docker.sh"),
-                utils._to_bash_path(tmp_path),
+                utils._to_bash_path(directory),
             ],
             capture_output=True,
             text=True,
@@ -252,9 +243,49 @@ def test_get_image_name_falls_back_to_environment_dockerfile(tmp_path: Path):
         )
     except FileNotFoundError:
         pytest.skip("bash not available")
-
     assert result.returncode == 0, f"get_image_name failed (stderr: {result.stderr})"
-    assert "image=skillbench:" in result.stdout
+    return result.stdout.strip()
+
+
+def test_get_image_name_falls_back_to_environment_dockerfile(tmp_path: Path):
+    """get_image_name() resolves environment/Dockerfile when dir/Dockerfile is absent.
+
+    docker_build() falls back to environment/Dockerfile, so get_image_name() must
+    apply the same rule; otherwise the fallback in docker_build() is dead code and
+    building a workspace that only carries an environment/Dockerfile always fails.
+    """
+    env_dir = tmp_path / "environment"
+    env_dir.mkdir()
+    (env_dir / "Dockerfile").write_text("FROM python:3.11-slim\n", encoding="utf-8")
+
+    assert "image=skillbench:" in _get_image_name(tmp_path)
+
+
+def test_get_image_name_prefers_root_dockerfile_over_environment(tmp_path: Path):
+    """When both dir/Dockerfile and environment/Dockerfile exist, prefer the root one.
+
+    The environment/ fallback only applies when the root Dockerfile is absent, mirroring
+    docker_build()'s resolution order.
+    """
+    root_only = tmp_path / "root-only"
+    root_only.mkdir()
+    (root_only / "Dockerfile").write_text("FROM node:22\n", encoding="utf-8")
+
+    both = tmp_path / "both"
+    both.mkdir()
+    (both / "Dockerfile").write_text("FROM node:22\n", encoding="utf-8")
+    both_env = both / "environment"
+    both_env.mkdir()
+    (both_env / "Dockerfile").write_text("FROM python:3.11-slim\n", encoding="utf-8")
+
+    env_only = tmp_path / "env-only"
+    env_only.mkdir()
+    env_only_env = env_only / "environment"
+    env_only_env.mkdir()
+    (env_only_env / "Dockerfile").write_text("FROM python:3.11-slim\n", encoding="utf-8")
+
+    assert _get_image_name(root_only) == _get_image_name(both)
+    assert _get_image_name(both) != _get_image_name(env_only)
 
 
 def test_run_claude_fixture_defaults_langsmith_hook_log_path():

--- a/eval/local/tests/scaffold/test_utils.py
+++ b/eval/local/tests/scaffold/test_utils.py
@@ -258,7 +258,10 @@ def test_get_image_name_falls_back_to_environment_dockerfile(tmp_path: Path):
     env_dir.mkdir()
     (env_dir / "Dockerfile").write_text("FROM python:3.11-slim\n", encoding="utf-8")
 
-    assert "image=skillbench:" in _get_image_name(tmp_path)
+    root_dir = tmp_path / "root"
+    root_dir.mkdir()
+    (root_dir / "Dockerfile").write_text("FROM python:3.11-slim\n", encoding="utf-8")
+    assert _get_image_name(tmp_path) == _get_image_name(root_dir)
 
 
 def test_get_image_name_prefers_root_dockerfile_over_environment(tmp_path: Path):

--- a/eval/scaffold/shell/docker.sh
+++ b/eval/scaffold/shell/docker.sh
@@ -109,6 +109,11 @@ get_dockerfile_hash() {
     local dockerfile="$dir/Dockerfile"
 
     if [[ ! -f "$dockerfile" ]]; then
+        # Fall back to environment/Dockerfile (same layout as docker_build).
+        dockerfile="$dir/environment/Dockerfile"
+    fi
+
+    if [[ ! -f "$dockerfile" ]]; then
         echo ""
         return 1
     fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rpamis/comet",
-  "version": "0.4.0-beta.14",
+  "version": "0.4.0-beta.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rpamis/comet",
-      "version": "0.4.0-beta.14",
+      "version": "0.4.0-beta.15",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rpamis/comet",
-  "version": "0.4.0-beta.14",
+  "version": "0.4.0-beta.15",
   "description": "Agent Skill Harness For Turning Ideas Into Evaluated Workflows",
   "keywords": [
     "comet",

--- a/test/app/cli-help.test.ts
+++ b/test/app/cli-help.test.ts
@@ -29,7 +29,7 @@ describe('CLI help text', () => {
     expect(help.status, help.stderr).toBe(0);
     expect(help.stdout).toContain(tagline);
     expect(packageJson.description).toBe(tagline);
-    expect(packageJson.version).toBe('0.4.0-beta.14');
+    expect(packageJson.version).toBe('0.4.0-beta.15');
   });
 
   it('marks bundle as the advanced backend and skill Engine runs as advanced', () => {

--- a/test/repository/release-metadata.test.ts
+++ b/test/repository/release-metadata.test.ts
@@ -16,7 +16,7 @@ describe('release metadata', () => {
       readFileSync(path.join(repositoryRoot, 'assets', 'manifest.json'), 'utf8'),
     ) as { version: string };
 
-    expect(packageJson.version).toBe('0.4.0-beta.14');
+    expect(packageJson.version).toBe('0.4.0-beta.15');
     expect(packageLock.version).toBe(packageJson.version);
     expect(packageLock.packages[''].version).toBe(packageJson.version);
     expect(assetsManifest.version).toBe(packageJson.version);


### PR DESCRIPTION
## ✨ Summary

`get_dockerfile_hash()` in `eval/scaffold/shell/docker.sh` only checked for `dir/Dockerfile`, even though `docker_build()` already falls back to `dir/environment/Dockerfile` (the eval layout where task environments live under `environment/`). Because `get_image_name()` calls `get_dockerfile_hash()` before the build, that fallback was dead code: passing a workspace that only carries `environment/Dockerfile` (e.g. comet-any direct calls or validator scenarios) made image lookup fail before any Docker command ran.

This PR applies the same fallback to `get_dockerfile_hash()`, keeping the two functions consistent, and bumps the version to `0.4.0-beta.15`.

## 🎯 Scope

- [ ] CLI commands (`init`, `status`, `doctor`, `update`)
- [ ] Core installer / platform detection
- [ ] Comet skills (`assets/skills/`, `assets/skills-zh/`)
- [ ] Comet shell scripts (`assets/skills/comet/scripts/`)
- [x] Tests / CI
- [x] Documentation / changelog
- [x] Other: Eval scaffold shell script (`eval/scaffold/shell/docker.sh`), release metadata

## 🧪 Testing

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm build`
- [x] `pnpm lint` (ESLint + architecture linter)
- [x] `pnpm format:check` — every file changed by this PR passes; the repo-wide check only flags the known `domains/dashboard/web/` Windows CRLF boundary files, which are byte-identical to `origin/master` (flagged identically on `master`, passes on CI's Linux checkout)
- [x] `pnpm test` (full) — result identical to `master`: 8 files / 39 tests fail on Windows (pre-existing openspec/path-integration environment failures), 2991 pass; this PR introduces zero regressions
- [x] `uv run pytest -q local/tests/scaffold local/tests/tasks/test_validation_scripts.py` — 341 passed (one more than `master`, the new regression test); the same 5 pre-existing failures as `master`
- [x] `uv run pytest local/tests/scaffold/test_utils.py::test_get_image_name_falls_back_to_environment_dockerfile` (new regression test; red before the fix, green after)
- [x] `uv run pytest local/tests/scaffold/test_utils.py::test_get_image_name_prefers_root_dockerfile_over_environment` (complementary priority test, added after review)
- [x] `uv run --extra dev ruff check local/tests/scaffold/test_utils.py`

## ✅ Checklist

- [x] PR title follows Conventional Commits
- [x] User-facing behavior is documented in `CHANGELOG.md`
- [x] `CHANGELOG.md` is updated when behavior changes
- [ ] Skill changes were made in Chinese first when applicable, then synced to English
- [ ] New scripts are included in `assets/manifest.json` and relevant tests
- [x] Shell scripts remain portable across macOS, Linux, and Windows Git Bash
- [x] No unrelated generated files or local artifacts are included

## 👀 Notes for Reviewers

The fix mirrors the existing fallback in `docker_build()` (lines 222-226). This PR also bumps the version to `0.4.0-beta.15` per the one-version-ahead rule (master is `0.4.0-beta.14`), syncing `package-lock.json`, `assets/manifest.json`, and the version assertions in `test/repository/release-metadata.test.ts` and `test/app/cli-help.test.ts`. The branch was rebased onto the latest `master` after the `0.4.0-beta.13`/`0.4.0-beta.14` releases, resolving the version-field conflicts.

The READMEs are intentionally unchanged: this is an internal eval-scaffold fix whose user-visible effect is recorded in the changelog, and the repo keeps README updates restrained. Known boundary: `get_dockerfile_hash()` applies the `environment/` fallback to `Dockerfile` only, not to `requirements.txt`; no current eval task keeps `requirements.txt` under `environment/`, so this does not affect existing workloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Dockerfile detection during evaluation workflows by checking the environment-specific Dockerfile when no root-level Dockerfile is available.
  - Ensured Docker image identification remains consistent with the build process.

- **Tests**
  - Added coverage for Dockerfile selection across supported workspace layouts.

- **Release**
  - Updated application and release metadata to version `0.4.0-beta.15`.
  - Updated the changelog with the latest release information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->