### PR TITLE
fix: sync global Native Skills during update

### DIFF
--- a/app/commands/update.ts
+++ b/app/commands/update.ts
@@ -15,6 +15,7 @@ import {
 import {
   copyCometSkillsForPlatform,
   copyCometRulesForPlatform,
+  detectInstalledWorkflowSelection,
   installCometHooksForPlatform,
   getManifestSkills,
   mergeProjectConfig,
@@ -1545,12 +1546,9 @@ async function updateSingleProject(
   // Global scope mirrors `comet init`: `comet update --scope global` must keep
   // already-installed Skills in sync without expanding the workflow range the
   // user chose at install time. The selection is derived from what is on disk
-  // by checking the two workflow markers, comet-native/SKILL.md and
-  // comet-classic/SKILL.md:
-  //   neither / classic only -> 'classic'  (no Native added)
-  //   native only            -> 'native'   (no Classic added)
-  //   both                   -> 'both'
-  // Project scope keeps honoring the project workflow configuration.
+  // by checking the two workflow markers (see detectInstalledWorkflowSelection
+  // in domains/skill/platform-install.ts). Project scope keeps honoring the
+  // project workflow configuration.
   const skillWorkflowSelectionFor = async (
     target: InstalledCometTarget,
   ): Promise<InitWorkflowSelection> => {
@@ -1560,13 +1558,7 @@ async function updateSingleProject(
       getPlatformSkillsDir(target.platform, 'global'),
       'skills',
     );
-    const [hasNative, hasClassic] = await Promise.all([
-      fileExists(path.join(skillsRoot, 'comet-native', 'SKILL.md')),
-      fileExists(path.join(skillsRoot, 'comet-classic', 'SKILL.md')),
-    ]);
-    if (hasNative && hasClassic) return 'both';
-    if (hasNative) return 'native';
-    return 'classic';
+    return detectInstalledWorkflowSelection(skillsRoot);
   };
   const targetWorkflowSelections = await Promise.all(targets.map(skillWorkflowSelectionFor));
   const updateSkillPaths = new Set(

--- a/app/commands/update.ts
+++ b/app/commands/update.ts
@@ -1542,26 +1542,31 @@ async function updateSingleProject(
     );
   }
 
-  // Global scope mirrors `comet init`: when a user installs Native Skills
-  // globally (e.g. via `comet init --scope global --workflow native`), later
-  // `comet update --scope global` must keep those Skills in sync without
-  // expanding a Classic-only install. The selection is therefore derived from
-  // what is already on disk: an existing comet-native Skill selects 'both' so
-  // it stays current, while a Classic-only install keeps 'classic' so update
-  // never adds Native Skills the user did not choose. Project scope keeps
-  // honoring the project workflow configuration.
+  // Global scope mirrors `comet init`: `comet update --scope global` must keep
+  // already-installed Skills in sync without expanding the workflow range the
+  // user chose at install time. The selection is derived from what is on disk
+  // by checking the two workflow markers, comet-native/SKILL.md and
+  // comet-classic/SKILL.md:
+  //   neither / classic only -> 'classic'  (no Native added)
+  //   native only            -> 'native'   (no Classic added)
+  //   both                   -> 'both'
+  // Project scope keeps honoring the project workflow configuration.
   const skillWorkflowSelectionFor = async (
     target: InstalledCometTarget,
   ): Promise<InitWorkflowSelection> => {
     if (target.scope !== 'global') return projectWorkflowSelection;
-    const nativeSkillPath = path.join(
+    const skillsRoot = path.join(
       getBaseDir('global', projectPath),
       getPlatformSkillsDir(target.platform, 'global'),
       'skills',
-      'comet-native',
-      'SKILL.md',
     );
-    return (await fileExists(nativeSkillPath)) ? 'both' : 'classic';
+    const [hasNative, hasClassic] = await Promise.all([
+      fileExists(path.join(skillsRoot, 'comet-native', 'SKILL.md')),
+      fileExists(path.join(skillsRoot, 'comet-classic', 'SKILL.md')),
+    ]);
+    if (hasNative && hasClassic) return 'both';
+    if (hasNative) return 'native';
+    return 'classic';
   };
   const targetWorkflowSelections = await Promise.all(targets.map(skillWorkflowSelectionFor));
   const updateSkillPaths = new Set(

--- a/app/commands/update.ts
+++ b/app/commands/update.ts
@@ -1544,14 +1544,26 @@ async function updateSingleProject(
 
   // Global scope mirrors `comet init`: when a user installs Native Skills
   // globally (e.g. via `comet init --scope global --workflow native`), later
-  // `comet update --scope global` must keep those Skills in sync. Rules and
-  // hooks stay on the Classic selection because their workflowSelection is
-  // effectively ignored (managedRulesForSelection / managedHooksForSelection
-  // return the full manifest set), and Native write-guarding is routed through
-  // the unified comet-hook-router rather than per-workflow rule/hook files.
-  const skillWorkflowSelectionFor = (target: InstalledCometTarget): InitWorkflowSelection =>
-    target.scope === 'global' ? 'both' : projectWorkflowSelection;
-  const targetWorkflowSelections = targets.map(skillWorkflowSelectionFor);
+  // `comet update --scope global` must keep those Skills in sync without
+  // expanding a Classic-only install. The selection is therefore derived from
+  // what is already on disk: an existing comet-native Skill selects 'both' so
+  // it stays current, while a Classic-only install keeps 'classic' so update
+  // never adds Native Skills the user did not choose. Project scope keeps
+  // honoring the project workflow configuration.
+  const skillWorkflowSelectionFor = async (
+    target: InstalledCometTarget,
+  ): Promise<InitWorkflowSelection> => {
+    if (target.scope !== 'global') return projectWorkflowSelection;
+    const nativeSkillPath = path.join(
+      getBaseDir('global', projectPath),
+      getPlatformSkillsDir(target.platform, 'global'),
+      'skills',
+      'comet-native',
+      'SKILL.md',
+    );
+    return (await fileExists(nativeSkillPath)) ? 'both' : 'classic';
+  };
+  const targetWorkflowSelections = await Promise.all(targets.map(skillWorkflowSelectionFor));
   const updateSkillPaths = new Set(
     (
       await Promise.all(
@@ -1578,7 +1590,7 @@ async function updateSingleProject(
     const languageSkillsDir = languageToSkillsDir(languageId);
     const targetInstallMode = installModeFor(target);
     const nativeProjectTarget = nativeProject && target.scope === 'project';
-    const targetSkillWorkflowSelection = skillWorkflowSelectionFor(target);
+    const targetSkillWorkflowSelection = await skillWorkflowSelectionFor(target);
     if (target.scope === 'project') {
       await assertClassicProjectMutationAllowed?.();
     }

--- a/app/commands/update.ts
+++ b/app/commands/update.ts
@@ -1549,9 +1549,9 @@ async function updateSingleProject(
   // effectively ignored (managedRulesForSelection / managedHooksForSelection
   // return the full manifest set), and Native write-guarding is routed through
   // the unified comet-hook-router rather than per-workflow rule/hook files.
-  const targetWorkflowSelections = targets.map((target) =>
-    target.scope === 'global' ? 'both' : projectWorkflowSelection,
-  );
+  const skillWorkflowSelectionFor = (target: InstalledCometTarget): InitWorkflowSelection =>
+    target.scope === 'global' ? 'both' : projectWorkflowSelection;
+  const targetWorkflowSelections = targets.map(skillWorkflowSelectionFor);
   const updateSkillPaths = new Set(
     (
       await Promise.all(
@@ -1578,8 +1578,7 @@ async function updateSingleProject(
     const languageSkillsDir = languageToSkillsDir(languageId);
     const targetInstallMode = installModeFor(target);
     const nativeProjectTarget = nativeProject && target.scope === 'project';
-    const targetSkillWorkflowSelection =
-      target.scope === 'global' ? 'both' : projectWorkflowSelection;
+    const targetSkillWorkflowSelection = skillWorkflowSelectionFor(target);
     if (target.scope === 'project') {
       await assertClassicProjectMutationAllowed?.();
     }

--- a/app/commands/update.ts
+++ b/app/commands/update.ts
@@ -1542,8 +1542,15 @@ async function updateSingleProject(
     );
   }
 
+  // Global scope mirrors `comet init`: when a user installs Native Skills
+  // globally (e.g. via `comet init --scope global --workflow native`), later
+  // `comet update --scope global` must keep those Skills in sync. Rules and
+  // hooks stay on the Classic selection because their workflowSelection is
+  // effectively ignored (managedRulesForSelection / managedHooksForSelection
+  // return the full manifest set), and Native write-guarding is routed through
+  // the unified comet-hook-router rather than per-workflow rule/hook files.
   const targetWorkflowSelections = targets.map((target) =>
-    target.scope === 'global' ? 'classic' : projectWorkflowSelection,
+    target.scope === 'global' ? 'both' : projectWorkflowSelection,
   );
   const updateSkillPaths = new Set(
     (
@@ -1571,8 +1578,8 @@ async function updateSingleProject(
     const languageSkillsDir = languageToSkillsDir(languageId);
     const targetInstallMode = installModeFor(target);
     const nativeProjectTarget = nativeProject && target.scope === 'project';
-    const targetWorkflowSelection =
-      target.scope === 'global' ? 'classic' : projectWorkflowSelection;
+    const targetSkillWorkflowSelection =
+      target.scope === 'global' ? 'both' : projectWorkflowSelection;
     if (target.scope === 'project') {
       await assertClassicProjectMutationAllowed?.();
     }
@@ -1581,7 +1588,7 @@ async function updateSingleProject(
         baseDir,
         target.platform,
         target.scope,
-        targetWorkflowSelection,
+        targetSkillWorkflowSelection,
       );
     }
     const { copied, skipped, failed } = await copyCometSkillsForPlatform(
@@ -1591,7 +1598,7 @@ async function updateSingleProject(
       languageSkillsDir,
       target.scope,
       targetInstallMode,
-      targetWorkflowSelection,
+      targetSkillWorkflowSelection,
     );
     const cleanupResult =
       failed === 0

--- a/domains/skill/platform-install.ts
+++ b/domains/skill/platform-install.ts
@@ -458,6 +458,9 @@ async function installSkillsAsSymlink(
   let copied = 0;
   let skippedCount = 0;
   let failedCount = 0;
+  // Count manifest entries filtered out by the workflow selection so the
+  // symlink path reports skipped files consistently with copy mode.
+  skippedCount += getManagedSkillPaths(manifest).length - managedSkillPaths.length;
 
   for (const skillRelPath of managedSkillPaths) {
     const isScript = skillRelPath.includes('/scripts/');
@@ -566,6 +569,11 @@ async function copyCometSkillsForPlatform(
   let failedCount = 0;
   const managedSkillPaths = getManagedSkillPathsForSelection(manifest, workflowSelection);
   const userFacingSkillPaths = getUserFacingSkillPathsForSelection(manifest, workflowSelection);
+  // Count manifest entries that the workflow selection filters out so the
+  // update summary stays honest: a Classic-only update reports the Native
+  // files it intentionally skips instead of pretending they do not exist.
+  const filteredCount = getManagedSkillPaths(manifest).length - managedSkillPaths.length;
+  skippedCount += filteredCount;
 
   for (const skillRelPath of managedSkillPaths) {
     const isScript = skillRelPath.includes('/scripts/');

--- a/domains/skill/platform-install.ts
+++ b/domains/skill/platform-install.ts
@@ -115,6 +115,30 @@ function isManagedSkillPathForSelection(
   );
 }
 
+/**
+ * Derive the workflow selection from the Skills already on disk by checking
+ * the two workflow markers (comet-native/SKILL.md and comet-classic/SKILL.md).
+ * This lets `comet update` keep already-installed workflows in sync without
+ * expanding the range the user chose at install time:
+ *   neither / classic only -> 'classic'  (no Native added)
+ *   native only            -> 'native'   (no Classic added)
+ *   both                   -> 'both'
+ * The caller is responsible for computing `skillsRoot` (e.g. base dir +
+ * platform skills dir + 'skills'); this function only performs the marker
+ * check and mapping.
+ */
+export async function detectInstalledWorkflowSelection(
+  skillsRoot: string,
+): Promise<InitWorkflowSelection> {
+  const [hasNative, hasClassic] = await Promise.all([
+    fileExists(path.join(skillsRoot, 'comet-native', 'SKILL.md')),
+    fileExists(path.join(skillsRoot, 'comet-classic', 'SKILL.md')),
+  ]);
+  if (hasNative && hasClassic) return 'both';
+  if (hasNative) return 'native';
+  return 'classic';
+}
+
 function getManagedSkillPathsForSelection(
   manifest: Manifest,
   workflowSelection: InitWorkflowSelection,

--- a/test/app/update.test.ts
+++ b/test/app/update.test.ts
@@ -3322,12 +3322,12 @@ describe('update command helpers', () => {
     await expect(fs.stat(path.join(fakeHome, 'docs', 'superpowers'))).rejects.toThrow();
   });
 
-  it('syncs Native Skills during a global update without expanding a Native install', async () => {
+  it('syncs Native Skills during a global update of a Native+Classic install', async () => {
     // Regression for #262: global scope used to hardcode the Skill
     // workflowSelection to 'classic', which filtered out comet-native/* and
-    // left global Native installs frozen at their first-install version. The
-    // selection is now derived from disk: an existing comet-native Skill
-    // selects 'both' so it stays current.
+    // left global Native installs frozen at their first-install version. With
+    // both comet-native and comet-classic on disk the selection is 'both', so
+    // Native Skills stay current.
     const fakeHome = path.join(tmpDir, 'fake-home-global-native-sync');
     await fs.mkdir(path.join(fakeHome, '.codex', 'skills', 'comet'), { recursive: true });
     await fs.writeFile(
@@ -3335,14 +3335,23 @@ describe('update command helpers', () => {
       '# Comet\n',
       'utf-8',
     );
-    // Seed a stale Native install so the test also proves an existing
-    // comet-native Skill gets overwritten, not merely created.
+    // Seed a both-workflow install: stale comet-native plus comet-classic so
+    // the derived selection is 'both', and prove the stale Native Skill is
+    // overwritten rather than merely created.
     await fs.mkdir(path.join(fakeHome, '.agents', 'skills', 'comet-native'), {
       recursive: true,
     });
     await fs.writeFile(
       path.join(fakeHome, '.agents', 'skills', 'comet-native', 'SKILL.md'),
       '---\nname: comet-native\n---\n# STALE\n',
+      'utf-8',
+    );
+    await fs.mkdir(path.join(fakeHome, '.agents', 'skills', 'comet-classic'), {
+      recursive: true,
+    });
+    await fs.writeFile(
+      path.join(fakeHome, '.agents', 'skills', 'comet-classic', 'SKILL.md'),
+      '# stale classic\n',
       'utf-8',
     );
     const homeSpy = vi.spyOn(os, 'homedir').mockReturnValue(fakeHome);
@@ -3420,6 +3429,61 @@ describe('update command helpers', () => {
     ).rejects.toMatchObject({ code: 'ENOENT' });
 
     // The Native manifest entries filtered out by the Classic selection are
+    // reported as skipped rather than hidden.
+    const result = json ? JSON.parse(json) : {};
+    const codexSkills = (result.skills?.targets ?? []).find(
+      (t: { platform: string }) => t.platform === 'codex',
+    );
+    expect(codexSkills?.skipped).toBeGreaterThan(0);
+  });
+
+  it('does not add Classic Skills to a Native-only global install during update', async () => {
+    // A global install created with `comet init --scope global --workflow
+    // native` must not gain comet-classic after `comet update --scope global`.
+    const fakeHome = path.join(tmpDir, 'fake-home-global-native-only');
+    await fs.mkdir(path.join(fakeHome, '.codex', 'skills', 'comet'), { recursive: true });
+    await fs.writeFile(
+      path.join(fakeHome, '.codex', 'skills', 'comet', 'SKILL.md'),
+      '# Comet\n',
+      'utf-8',
+    );
+    // Native-only install: comet-native present, comet-classic absent.
+    await fs.mkdir(path.join(fakeHome, '.agents', 'skills', 'comet-native'), {
+      recursive: true,
+    });
+    await fs.writeFile(
+      path.join(fakeHome, '.agents', 'skills', 'comet-native', 'SKILL.md'),
+      '---\nname: comet-native\n---\n# STALE\n',
+      'utf-8',
+    );
+    const homeSpy = vi.spyOn(os, 'homedir').mockReturnValue(fakeHome);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    let json: string | undefined;
+
+    try {
+      await updateCommand(tmpDir, {
+        json: true,
+        skipNpm: true,
+        scope: 'global',
+      });
+      json = log.mock.calls.map((call) => call.join(' ')).join('\n');
+    } finally {
+      log.mockRestore();
+      homeSpy.mockRestore();
+    }
+
+    // Native Skills update, but comet-classic must NOT be introduced.
+    const nativeSkill = await fs.readFile(
+      path.join(fakeHome, '.agents', 'skills', 'comet-native', 'SKILL.md'),
+      'utf8',
+    );
+    expect(nativeSkill).toContain('name: comet-native');
+    expect(nativeSkill).not.toContain('# STALE');
+    await expect(
+      fs.access(path.join(fakeHome, '.agents', 'skills', 'comet-classic', 'SKILL.md')),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+
+    // The Classic manifest entries filtered out by the Native selection are
     // reported as skipped rather than hidden.
     const result = json ? JSON.parse(json) : {};
     const codexSkills = (result.skills?.targets ?? []).find(

--- a/test/app/update.test.ts
+++ b/test/app/update.test.ts
@@ -3322,10 +3322,12 @@ describe('update command helpers', () => {
     await expect(fs.stat(path.join(fakeHome, 'docs', 'superpowers'))).rejects.toThrow();
   });
 
-  it('syncs Native Skills during a global update', async () => {
+  it('syncs Native Skills during a global update without expanding a Native install', async () => {
     // Regression for #262: global scope used to hardcode the Skill
     // workflowSelection to 'classic', which filtered out comet-native/* and
-    // left global Native installs frozen at their first-install version.
+    // left global Native installs frozen at their first-install version. The
+    // selection is now derived from disk: an existing comet-native Skill
+    // selects 'both' so it stays current.
     const fakeHome = path.join(tmpDir, 'fake-home-global-native-sync');
     await fs.mkdir(path.join(fakeHome, '.codex', 'skills', 'comet'), { recursive: true });
     await fs.writeFile(
@@ -3346,6 +3348,7 @@ describe('update command helpers', () => {
     const homeSpy = vi.spyOn(os, 'homedir').mockReturnValue(fakeHome);
     // Silence update progress logging; this test only asserts file contents.
     const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    let json: string | undefined;
 
     try {
       await updateCommand(tmpDir, {
@@ -3353,6 +3356,7 @@ describe('update command helpers', () => {
         skipNpm: true,
         scope: 'global',
       });
+      json = log.mock.calls.map((call) => call.join(' ')).join('\n');
     } finally {
       log.mockRestore();
       homeSpy.mockRestore();
@@ -3370,6 +3374,58 @@ describe('update command helpers', () => {
     await expect(
       fs.readFile(path.join(fakeHome, '.agents', 'skills', 'comet', 'SKILL.md'), 'utf8'),
     ).resolves.toContain('comet workflow resolve');
+
+    // With 'both' selected, no manifest entries are filtered out, so the
+    // Codex target reports zero skipped Skills.
+    const result = json ? JSON.parse(json) : {};
+    const codexSkills = (result.skills?.targets ?? []).find(
+      (t: { platform: string }) => t.platform === 'codex',
+    );
+    expect(codexSkills?.skipped).toBe(0);
+  });
+
+  it('does not add Native Skills to a Classic-only global install during update', async () => {
+    // A global install created with `comet init --scope global --workflow
+    // classic` must not gain comet-native after `comet update --scope global`.
+    const fakeHome = path.join(tmpDir, 'fake-home-global-classic-only');
+    await fs.mkdir(path.join(fakeHome, '.codex', 'skills', 'comet'), { recursive: true });
+    await fs.writeFile(
+      path.join(fakeHome, '.codex', 'skills', 'comet', 'SKILL.md'),
+      '# Comet\n',
+      'utf-8',
+    );
+    // No comet-native directory: this is a Classic-only install.
+    const homeSpy = vi.spyOn(os, 'homedir').mockReturnValue(fakeHome);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    let json: string | undefined;
+
+    try {
+      await updateCommand(tmpDir, {
+        json: true,
+        skipNpm: true,
+        scope: 'global',
+      });
+      json = log.mock.calls.map((call) => call.join(' ')).join('\n');
+    } finally {
+      log.mockRestore();
+      homeSpy.mockRestore();
+    }
+
+    // Classic Skills update, but comet-native must NOT be introduced.
+    await expect(
+      fs.readFile(path.join(fakeHome, '.agents', 'skills', 'comet', 'SKILL.md'), 'utf8'),
+    ).resolves.toContain('comet workflow resolve');
+    await expect(
+      fs.access(path.join(fakeHome, '.agents', 'skills', 'comet-native', 'SKILL.md')),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+
+    // The Native manifest entries filtered out by the Classic selection are
+    // reported as skipped rather than hidden.
+    const result = json ? JSON.parse(json) : {};
+    const codexSkills = (result.skills?.targets ?? []).find(
+      (t: { platform: string }) => t.platform === 'codex',
+    );
+    expect(codexSkills?.skipped).toBeGreaterThan(0);
   });
 
   it('preserves installed language for an explicit global platform update', async () => {

--- a/test/app/update.test.ts
+++ b/test/app/update.test.ts
@@ -3333,7 +3333,18 @@ describe('update command helpers', () => {
       '# Comet\n',
       'utf-8',
     );
+    // Seed a stale Native install so the test also proves an existing
+    // comet-native Skill gets overwritten, not merely created.
+    await fs.mkdir(path.join(fakeHome, '.agents', 'skills', 'comet-native'), {
+      recursive: true,
+    });
+    await fs.writeFile(
+      path.join(fakeHome, '.agents', 'skills', 'comet-native', 'SKILL.md'),
+      '---\nname: comet-native\n---\n# STALE\n',
+      'utf-8',
+    );
     const homeSpy = vi.spyOn(os, 'homedir').mockReturnValue(fakeHome);
+    // Silence update progress logging; this test only asserts file contents.
     const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
     try {
@@ -3348,10 +3359,14 @@ describe('update command helpers', () => {
     }
 
     // Native Skills must be copied alongside Classic ones for global installs.
-    // Codex installs land in the canonical `.agents/skills/` directory.
-    await expect(
-      fs.readFile(path.join(fakeHome, '.agents', 'skills', 'comet-native', 'SKILL.md'), 'utf8'),
-    ).resolves.toContain('name: comet-native');
+    // Codex installs land in the canonical `.agents/skills/` directory, and a
+    // previously stale Native Skill must be replaced with the current asset.
+    const nativeSkill = await fs.readFile(
+      path.join(fakeHome, '.agents', 'skills', 'comet-native', 'SKILL.md'),
+      'utf8',
+    );
+    expect(nativeSkill).toContain('name: comet-native');
+    expect(nativeSkill).not.toContain('# STALE');
     await expect(
       fs.readFile(path.join(fakeHome, '.agents', 'skills', 'comet', 'SKILL.md'), 'utf8'),
     ).resolves.toContain('comet workflow resolve');

--- a/test/app/update.test.ts
+++ b/test/app/update.test.ts
@@ -3322,6 +3322,41 @@ describe('update command helpers', () => {
     await expect(fs.stat(path.join(fakeHome, 'docs', 'superpowers'))).rejects.toThrow();
   });
 
+  it('syncs Native Skills during a global update', async () => {
+    // Regression for #262: global scope used to hardcode the Skill
+    // workflowSelection to 'classic', which filtered out comet-native/* and
+    // left global Native installs frozen at their first-install version.
+    const fakeHome = path.join(tmpDir, 'fake-home-global-native-sync');
+    await fs.mkdir(path.join(fakeHome, '.codex', 'skills', 'comet'), { recursive: true });
+    await fs.writeFile(
+      path.join(fakeHome, '.codex', 'skills', 'comet', 'SKILL.md'),
+      '# Comet\n',
+      'utf-8',
+    );
+    const homeSpy = vi.spyOn(os, 'homedir').mockReturnValue(fakeHome);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    try {
+      await updateCommand(tmpDir, {
+        json: true,
+        skipNpm: true,
+        scope: 'global',
+      });
+    } finally {
+      log.mockRestore();
+      homeSpy.mockRestore();
+    }
+
+    // Native Skills must be copied alongside Classic ones for global installs.
+    // Codex installs land in the canonical `.agents/skills/` directory.
+    await expect(
+      fs.readFile(path.join(fakeHome, '.agents', 'skills', 'comet-native', 'SKILL.md'), 'utf8'),
+    ).resolves.toContain('name: comet-native');
+    await expect(
+      fs.readFile(path.join(fakeHome, '.agents', 'skills', 'comet', 'SKILL.md'), 'utf8'),
+    ).resolves.toContain('comet workflow resolve');
+  });
+
   it('preserves installed language for an explicit global platform update', async () => {
     const fakeHome = path.join(tmpDir, 'fake-home-explicit-global-language');
     await fs.mkdir(path.join(fakeHome, '.codex', 'skills', 'comet'), { recursive: true });


### PR DESCRIPTION
## 概述

修复 `comet update --scope global` 不再让 Native workflow 的 Skill 文件停留在首次安装版本。

## 问题

Closes #262。

`comet update` 在 target scope 为 `global` 时，把 Skill 的 `workflowSelection` 硬编码为 `'classic'`（`app/commands/update.ts`）。配合 `domains/skill/platform-install.ts` 中 `'classic'` 模式的过滤逻辑（排除所有 `comet-native/` 路径），整个 `comet-native/` 目录在复制前就被过滤掉了——于是 global 安装报告 `copied: 46, skipped: 0, failed: 0`，但 `~/.agents/skills/comet-native/*` 实际纹丝不动。

这与 `comet init` 的行为矛盾：`comet init` 允许用户全局安装 Native Skill（例如 `comet init --scope global --workflow native`），但一旦装上，`comet update` 永远无法更新它。

## 修复方案

对齐 `comet init`，让 global 的 **Skills** 选择 `'both'`，使 Native 文件保持同步。

- Skills（`copyCometSkillsForPlatform` / `prepareManagedSkillCopyTarget`）：global → `'both'`
- Rules（`copyCometRulesForPlatform`）和 hooks（`installCometHooksForPlatform`）：保持 `'classic'`。它们的 `workflowSelection` 参数是 dead parameter（`managedRulesForSelection` / `managedHooksForSelection` 忽略该参数，直接返回完整 manifest 集合），且 Native 写入护栏由统一的 `comet-hook-router` 路由，不需要 per-workflow 的 rule/hook 文件。

## 验证

- 新增回归测试 `syncs Native Skills during a global update`，断言 global update 会写入 `~/.agents/skills/comet-native/SKILL.md`。
- `test/app/update.test.ts` 全套 101 个测试通过，无回归。
- 改动文件 `eslint` / `prettier` 检查干净。

## 根因证据

- `app/commands/update.ts`（4 处硬编码；本 PR 修改其中影响 Skills 的 2 处）
- `domains/skill/platform-install.ts:108-109`（`'classic'` 排除 `comet-native/`）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Global skill updates now select the appropriate Classic, Native, or combined workflow.
  * Existing Native skills are refreshed without creating duplicate assets.
  * Classic-only installations remain free of Native assets.
  * Installation summaries now accurately report files skipped by workflow filtering.

* **Tests**
  * Added regression coverage for global workflow selection, workflow-specific skill refreshes, and filtered skill reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->