### PR TITLE
feat: add CodeBuddy rulesDir and rulesFormat support

### DIFF
--- a/platform/install/platforms.ts
+++ b/platform/install/platforms.ts
@@ -265,6 +265,8 @@ export const PLATFORMS: Platform[] = [
     openspecToolId: 'codebuddy',
     supportsHooks: true,
     hookFormat: 'codebuddy',
+    rulesDir: 'rules',
+    rulesFormat: 'md',
   },
   { id: 'costrict', name: 'CoStrict', skillsDir: '.cospec', openspecToolId: 'costrict' },
   { id: 'crush', name: 'Crush', skillsDir: '.crush', openspecToolId: 'crush' },


### PR DESCRIPTION
## ✨ Summary

Add `rulesDir: 'rules'` and `rulesFormat: 'md'` to the CodeBuddy platform definition. This enables `comet bundle distribute --platform codebuddy` to satisfy the `rules` capability validation and install Markdown rules under `.codebuddy/rules/`.

## 🎯 Scope

- [ ] CLI commands (`init`, `status`, `doctor`, `update`)
- [x] Core installer / platform detection
- [ ] Comet skills (`assets/skills/`, `assets/skills-zh/`)
- [ ] Comet shell scripts (`assets/skills/comet/scripts/`)
- [ ] Tests / CI
- [ ] Documentation / changelog
- [ ] Other: None

## 🧪 Testing

- [ ] `pnpm build`
- [ ] `pnpm lint`
- [ ] `pnpm run lint:architecture`
- [ ] `pnpm format:check`
- [ ] `pnpm test`
- [ ] `pnpm test -- test/domains/comet-classic/comet-scripts.test.ts`
- [x] Not run: The local commands above were not run as part of this PR update.
- Manual verification: `comet bundle distribute --platform codebuddy` was reported passing by the PR author, with rules installed under `.codebuddy/rules/`.

## ✅ Checklist

- [x] PR title follows Conventional Commits, for example `fix: handle project-scope init`
- [ ] User-facing behavior is documented in `README.md`, `README-zh.md`, or `CONTRIBUTING.md` (not applicable to this focused platform metadata change)
- [ ] `CHANGELOG.md` is updated when behavior changes (not updated in this PR)
- [x] Skill changes were made in Chinese first when applicable, then synced to English (not applicable)
- [x] New scripts are included in `assets/manifest.json` and relevant tests (not applicable)
- [x] Shell scripts remain portable across macOS, Linux, and Windows Git Bash (not applicable)
- [x] No unrelated generated files or local artifacts are included

## 👀 Notes for Reviewers

- The CodeBuddy platform entry is the only changed file: `platform/install/platforms.ts`.
- Required CI, CodeQL, quality/coverage, runtime smoke, cross-platform package-install, and workflow-lint checks are passing.
- The `greeting` check is currently failing and is unrelated to this platform capability change.
