### PR TITLE
fix(ci): allow greetings for fork pull requests

### DIFF
--- a/.github/workflows/greeting-guideline-pr.yml
+++ b/.github/workflows/greeting-guideline-pr.yml
@@ -1,7 +1,9 @@
 name: Greetings
 
 on:
-  pull_request:
+  # Run the base branch workflow so forked PRs can receive the first-interaction comment.
+  # This workflow must never check out or execute pull request code.
+  pull_request_target:
     types: [opened]
 
 permissions:

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -18,40 +18,48 @@ jobs:
         with:
           script: |
             const body = context.payload.pull_request?.body ?? '';
-            const requiredSections = [
-              '## ✨ Summary',
-              '## 🎯 Scope',
-              '## 🧪 Testing',
-              '## ✅ Checklist',
-              '## 👀 Notes for Reviewers',
-            ];
-            const missingSections = requiredSections.filter((heading) => !body.includes(heading));
-
-            function readSection(heading) {
-              const start = body.indexOf(heading);
-              if (start < 0) return '';
-              const content = body.slice(start + heading.length);
-              const nextHeading = content.search(/\n##\s/);
-              return nextHeading < 0 ? content : content.slice(0, nextHeading);
+            const baseSha = context.payload.pull_request?.base?.sha;
+            const templateResponse = await github.rest.repos.getContent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: '.github/PULL_REQUEST_TEMPLATE.md',
+              ref: baseSha,
+            });
+            if (Array.isArray(templateResponse.data) || !templateResponse.data.content) {
+              core.setFailed('Unable to read .github/PULL_REQUEST_TEMPLATE.md.');
+              return;
             }
 
-            const scope = readSection('## 🎯 Scope');
-            const testing = readSection('## 🧪 Testing');
-            const checklist = readSection('## ✅ Checklist');
-            const errors = missingSections.map((heading) => `Missing section: ${heading}`);
-
-            if (scope && !/^- \[x\] /im.test(scope)) {
-              errors.push('Select at least one item in the Scope section.');
-            }
-            if (testing && !/^- \[x\] /im.test(testing)) {
-              errors.push('Select at least one item in the Testing section, or select Not run.');
-            }
-            if (checklist) {
-              const unchecked = checklist.match(/^- \[ \] .+$/gim) ?? [];
-              if (unchecked.length > 0) {
-                errors.push(`Complete all Checklist items (${unchecked.length} remaining).`);
-              }
-            }
+            const template = Buffer.from(templateResponse.data.content, 'base64')
+              .toString('utf8')
+              .replace(/<!--[\s\S]*?-->/g, '');
+            const sections = [...template.matchAll(/^##\s+.+$/gm)].map((match, index, headings) => {
+              const start = match.index ?? 0;
+              const end = headings[index + 1]?.index ?? template.length;
+              return { heading: match[0].trim(), content: template.slice(start, end) };
+            });
+            const templateHeadings = sections.map((section) => section.heading);
+            const missingHeadings = templateHeadings.filter((heading) => !body.includes(heading));
+            const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const templateItems = sections.flatMap((section) =>
+              [...section.content.matchAll(/^- \[[ xX]\] (.+)$/gm)].map((match) => ({
+                section: section.heading,
+                label: match[1].trim(),
+              })),
+            );
+            const missingItems = templateItems.filter(
+              ({ label }) =>
+                !new RegExp(`^- \\[[ xX]\\] ${escapeRegExp(label)}\\s*$`, 'im').test(body),
+            );
+            const checklistItems = templateItems.filter(({ section }) => /checklist/i.test(section));
+            const uncheckedChecklistItems = checklistItems.filter(({ label }) =>
+              !new RegExp(`^- \\[xX\\] ${escapeRegExp(label)}\\s*$`, 'im').test(body),
+            );
+            const errors = missingHeadings.map((heading) => `Missing template section: ${heading}`);
+            errors.push(
+              ...missingItems.map(({ label }) => `Missing template item: ${label}`),
+              ...uncheckedChecklistItems.map(({ label }) => `Checklist item is not checked: ${label}`),
+            );
 
             const marker = '<!-- comet-pr-template-check -->';
             const comments = await github.rest.issues.listComments({
@@ -65,7 +73,7 @@ jobs:
                 comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker),
             );
             const commentBody = errors.length
-              ? `${marker}\n## PR template needs attention\n\nPlease update this PR to match .github/PULL_REQUEST_TEMPLATE.md:\n\n${errors.map((error) => `- ${error}`).join('\n')}\n`
+              ? `${marker}\n## PR template needs attention\n\nPlease update this PR to match the current .github/PULL_REQUEST_TEMPLATE.md:\n\n${errors.map((error) => `- ${error}`).join('\n')}\n`
               : `${marker}\n✅ PR template check passed.\n`;
 
             if (existing) {

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -1,0 +1,89 @@
+name: PR Template
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check-template:
+    name: PR template
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check pull request template
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        with:
+          script: |
+            const body = context.payload.pull_request?.body ?? '';
+            const requiredSections = [
+              '## ✨ Summary',
+              '## 🎯 Scope',
+              '## 🧪 Testing',
+              '## ✅ Checklist',
+              '## 👀 Notes for Reviewers',
+            ];
+            const missingSections = requiredSections.filter((heading) => !body.includes(heading));
+
+            function readSection(heading) {
+              const start = body.indexOf(heading);
+              if (start < 0) return '';
+              const content = body.slice(start + heading.length);
+              const nextHeading = content.search(/\n##\s/);
+              return nextHeading < 0 ? content : content.slice(0, nextHeading);
+            }
+
+            const scope = readSection('## 🎯 Scope');
+            const testing = readSection('## 🧪 Testing');
+            const checklist = readSection('## ✅ Checklist');
+            const errors = missingSections.map((heading) => `Missing section: ${heading}`);
+
+            if (scope && !/^- \[x\] /im.test(scope)) {
+              errors.push('Select at least one item in the Scope section.');
+            }
+            if (testing && !/^- \[x\] /im.test(testing)) {
+              errors.push('Select at least one item in the Testing section, or select Not run.');
+            }
+            if (checklist) {
+              const unchecked = checklist.match(/^- \[ \] .+$/gim) ?? [];
+              if (unchecked.length > 0) {
+                errors.push(`Complete all Checklist items (${unchecked.length} remaining).`);
+              }
+            }
+
+            const marker = '<!-- comet-pr-template-check -->';
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.data.find(
+              (comment) =>
+                comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker),
+            );
+            const commentBody = errors.length
+              ? `${marker}\n## PR template needs attention\n\nPlease update this PR to match .github/PULL_REQUEST_TEMPLATE.md:\n\n${errors.map((error) => `- ${error}`).join('\n')}\n`
+              : `${marker}\n✅ PR template check passed.\n`;
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: commentBody,
+              });
+            } else if (errors.length) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: commentBody,
+              });
+            }
+
+            if (errors.length) {
+              core.setFailed('Pull request does not satisfy the repository template.');
+            }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to @rpamis/comet will be documented in this file.
 ### Fixed
 
 - **Fork pull request greetings**: First-time contributors now receive the repository guidance comment when opening a pull request from a fork, without weakening the read-only permissions of workflows that execute contributor code.
+- **Pull request template checks**: Pull requests now receive an actionable comment and a failing check when required sections or checklist selections are missing.
 
 ## What's Changed [0.4.0-beta.18] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to @rpamis/comet will be documented in this file.
 ### Fixed
 
 - **Fork pull request greetings**: First-time contributors now receive the repository guidance comment when opening a pull request from a fork, without weakening the read-only permissions of workflows that execute contributor code.
-- **Pull request template checks**: Pull requests now receive an actionable comment and a failing check when required sections or checklist selections are missing.
+- **Pull request template checks**: Pull requests now receive an actionable comment and a failing check when items from the repository template are missing or its checklist is incomplete.
 
 ## What's Changed [0.4.0-beta.18] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to @rpamis/comet will be documented in this file.
 
 ## What's Changed [0.4.0-beta.19] - 2026-08-15
 
+### Changed
+
+- **Dashboard artifact previews**: Fullscreen previews now close with Escape, keep long tables horizontally scrollable, preserve readable table headers, and use a larger directory navigation scale.
+- **Hook allow-path documentation**: The website now explains how to configure project-relative `hook.allow_paths` directories for guarded workflow phases.
+
 ### Fixed
 
 - **Fork pull request greetings**: First-time contributors now receive the repository guidance comment when opening a pull request from a fork, without weakening the read-only permissions of workflows that execute contributor code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to @rpamis/comet will be documented in this file.
 
+## What's Changed [0.4.0-beta.19] - 2026-08-15
+
+### Fixed
+
+- **Fork pull request greetings**: First-time contributors now receive the repository guidance comment when opening a pull request from a fork, without weakening the read-only permissions of workflows that execute contributor code.
+
 ## What's Changed [0.4.0-beta.18] - 2026-08-13
 
 ### Added

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0-beta.18",
+  "version": "0.4.0-beta.19",
   "skills": [
     "comet/SKILL.md",
     "comet/agents/openai.yaml",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rpamis/comet",
-  "version": "0.4.0-beta.18",
+  "version": "0.4.0-beta.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rpamis/comet",
-      "version": "0.4.0-beta.18",
+      "version": "0.4.0-beta.19",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rpamis/comet",
-  "version": "0.4.0-beta.18",
+  "version": "0.4.0-beta.19",
   "description": "Agent Skill Harness For Turning Ideas Into Evaluated Workflows",
   "keywords": [
     "comet",

--- a/test/app/cli-help.test.ts
+++ b/test/app/cli-help.test.ts
@@ -29,7 +29,7 @@ describe('CLI help text', () => {
     expect(help.status, help.stderr).toBe(0);
     expect(help.stdout).toContain(tagline);
     expect(packageJson.description).toBe(tagline);
-    expect(packageJson.version).toBe('0.4.0-beta.18');
+    expect(packageJson.version).toBe('0.4.0-beta.19');
   });
 
   it('marks bundle as the advanced backend and skill Engine runs as advanced', () => {

--- a/test/repository/ci-workflows.test.ts
+++ b/test/repository/ci-workflows.test.ts
@@ -112,6 +112,29 @@ describe('CI workflows', () => {
     expect(workflow).not.toContain('actions/checkout');
   });
 
+  it('checks pull request template sections and reports actionable failures', async () => {
+    const workflow = await readWorkflow('pr-template-check.yml');
+    const template = await fs.readFile('.github/PULL_REQUEST_TEMPLATE.md', 'utf8');
+
+    expect(workflow).toContain('pull_request_target:');
+    expect(workflow).toContain('types: [opened, edited, reopened, synchronize, ready_for_review]');
+    expect(workflow).toContain('pull-requests: write');
+    expect(workflow).toContain('actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71');
+    expect(workflow).toContain('github.rest.issues.createComment');
+    expect(workflow).toContain('github.rest.issues.updateComment');
+    expect(workflow).toContain('core.setFailed');
+    expect(workflow).not.toContain('actions/checkout');
+    for (const heading of [
+      '## ✨ Summary',
+      '## 🎯 Scope',
+      '## 🧪 Testing',
+      '## ✅ Checklist',
+      '## 👀 Notes for Reviewers',
+    ]) {
+      expect(template).toContain(heading);
+    }
+  });
+
   it('defines stale PR auto-closing with a manual dry-run mode', async () => {
     const workflow = await readWorkflow('stale-prs.yml');
 

--- a/test/repository/ci-workflows.test.ts
+++ b/test/repository/ci-workflows.test.ts
@@ -120,19 +120,19 @@ describe('CI workflows', () => {
     expect(workflow).toContain('types: [opened, edited, reopened, synchronize, ready_for_review]');
     expect(workflow).toContain('pull-requests: write');
     expect(workflow).toContain('actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71');
+    expect(workflow).toContain('github.rest.repos.getContent');
+    expect(workflow).toContain("path: '.github/PULL_REQUEST_TEMPLATE.md'");
+    expect(workflow).toContain('context.payload.pull_request?.base?.sha');
+    expect(workflow).toContain('template.matchAll(/^##\\s+.+$/gm)');
+    expect(workflow).toContain('templateItems');
+    expect(workflow).toContain('uncheckedChecklistItems');
     expect(workflow).toContain('github.rest.issues.createComment');
     expect(workflow).toContain('github.rest.issues.updateComment');
     expect(workflow).toContain('core.setFailed');
     expect(workflow).not.toContain('actions/checkout');
-    for (const heading of [
-      '## ✨ Summary',
-      '## 🎯 Scope',
-      '## 🧪 Testing',
-      '## ✅ Checklist',
-      '## 👀 Notes for Reviewers',
-    ]) {
-      expect(template).toContain(heading);
-    }
+    expect(workflow).not.toContain('const requiredSections = [');
+    expect(template).toMatch(/^##\s+.+$/m);
+    expect(template).toMatch(/^- \[ \] .+$/m);
   });
 
   it('defines stale PR auto-closing with a manual dry-run mode', async () => {

--- a/test/repository/ci-workflows.test.ts
+++ b/test/repository/ci-workflows.test.ts
@@ -103,6 +103,15 @@ describe('CI workflows', () => {
     expect(workflow).toContain('subjectPattern: ^.{1,72}$');
   });
 
+  it('greets first-time contributors from the trusted base workflow', async () => {
+    const workflow = await readWorkflow('greeting-guideline-pr.yml');
+
+    expect(workflow).toMatch(/^  pull_request_target:$/m);
+    expect(workflow).not.toMatch(/^  pull_request:$/m);
+    expect(workflow).toContain('pull-requests: write');
+    expect(workflow).not.toContain('actions/checkout');
+  });
+
   it('defines stale PR auto-closing with a manual dry-run mode', async () => {
     const workflow = await readWorkflow('stale-prs.yml');
 

--- a/test/repository/release-metadata.test.ts
+++ b/test/repository/release-metadata.test.ts
@@ -16,7 +16,7 @@ describe('release metadata', () => {
       readFileSync(path.join(repositoryRoot, 'assets', 'manifest.json'), 'utf8'),
     ) as { version: string };
 
-    expect(packageJson.version).toBe('0.4.0-beta.18');
+    expect(packageJson.version).toBe('0.4.0-beta.19');
     expect(packageLock.version).toBe(packageJson.version);
     expect(packageLock.packages[''].version).toBe(packageJson.version);
     expect(assetsManifest.version).toBe(packageJson.version);


### PR DESCRIPTION
## Summary

- run the first-contributor greeting from the trusted base-branch workflow so fork pull requests can receive comments
- keep the privileged workflow from checking out or executing contributor code
- add a workflow contract test and publish the fix as `0.4.0-beta.19`

## Root cause

The greeting used the `pull_request` event. GitHub downgrades `GITHUB_TOKEN` to read-only for pull requests from forks, so `actions/first-interaction` failed with HTTP 403 when posting the guidance comment.

## Validation

- `vitest run test/repository/ci-workflows.test.ts test/repository/release-metadata.test.ts test/app/cli-help.test.ts` (22 passed)
- `pnpm lint`
- Prettier check for all affected files
- `git diff --check`

## Summary by Sourcery

Allow first-time contributor greeting comments on forked pull requests while keeping contributor code execution workflows read-only and safe.

Bug Fixes:
- Ensure first-time contributors opening pull requests from forks receive the guidance greeting comment without permission issues.

Enhancements:
- Guard the greeting workflow to run from the trusted base branch using pull_request_target and avoid checking out contributor code.

Build:
- Bump package and manifest versions to 0.4.0-beta.19.

Documentation:
- Update changelog with details of the fork pull request greeting fix for version 0.4.0-beta.19.

Tests:
- Add a CI workflow contract test for the greeting guideline workflow and update version expectations in existing tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - First-time contributors opening pull requests from forks can receive repository guidance comments.
  - Pull requests are checked for required template sections, scope and testing selections, and completed checklists.
  - Validation results appear in an updating pull request comment, with failed checks when requirements are incomplete.
  - Improved Dashboard artifact previews.

- **Documentation**
  - Clarified project-relative `hook.allow_paths` usage.

- **Release**
  - Updated the version to **0.4.0-beta.19**.
  - Added release notes for this version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->