### PR TITLE
fix(ci): accept standard [x] checklist marks in PR template check

### DIFF
--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -53,7 +53,7 @@ jobs:
             );
             const checklistItems = templateItems.filter(({ section }) => /checklist/i.test(section));
             const uncheckedChecklistItems = checklistItems.filter(({ label }) =>
-              !new RegExp(`^- \\[xX\\] ${escapeRegExp(label)}\\s*$`, 'im').test(body),
+              !new RegExp(`^- \\[[xX]\\] ${escapeRegExp(label)}\\s*$`, 'im').test(body),
             );
             const errors = missingHeadings.map((heading) => `Missing template section: ${heading}`);
             errors.push(


### PR DESCRIPTION
## ✨ Summary

The PR template check (`.github/workflows/pr-template-check.yml`) reported every pull request's checklist items as unchecked even when the boxes were marked with the standard `- [x]` checkbox.

Root cause: the `uncheckedChecklistItems` check used the regex `\[xX\]`, which matches the literal string `[xX]` (uppercase X) instead of a character class. Standard GitHub checklist marks are `- [x]` (lowercase), so every completed checklist item failed the check and blocked merging.

Fix: change `\[xX\]` to `\[[xX]\]` so it matches both `- [x]` and `- [X]` while still treating `- [ ]` as unchecked.

## 🎯 Scope

- [ ] CLI commands (`init`, `status`, `doctor`, `update`)
- [ ] Core installer / platform detection
- [ ] Comet skills (`assets/skills/`, `assets/skills-zh/`)
- [ ] Comet shell scripts (`assets/skills/comet/scripts/`)
- [x] Tests / CI
- [x] Documentation / changelog
- [ ] Other:

## 🧪 Testing

- [x] `pnpm build`
- [ ] `pnpm lint`
- [x] `pnpm run lint:architecture`
- [ ] `pnpm format:check`
- [x] `pnpm test`
- [ ] `pnpm test -- test/domains/comet-classic/comet-scripts.test.ts`
- [ ] Not run:

Additional focused validation:

- `npx vitest run test/repository/ci-workflows.test.ts test/repository/release-metadata.test.ts test/app/cli-help.test.ts test/repository/readme.test.ts` (34 passed)
- `npx prettier --check` on all changed files
- Reproduced the fix against the PR body with the workflow's exact regex: `[x]`/`[X]` pass, `[ ]` still reported as unchecked

## ✅ Checklist

- [x] PR title follows Conventional Commits, for example `fix: handle project-scope init`
- [x] User-facing behavior is documented in `README.md`, `README-zh.md`, or `CONTRIBUTING.md`
- [x] `CHANGELOG.md` is updated when behavior changes
- [x] Skill changes were made in Chinese first when applicable, then synced to English
- [x] New scripts are included in `assets/manifest.json` and relevant tests
- [x] Shell scripts remain portable across macOS, Linux, and Windows Git Bash
- [x] No unrelated generated files or local artifacts are included

## 👀 Notes for Reviewers

This is a one-character-class fix to the CI workflow added in #315. After this merges, PR #307 (and any other open PR) can re-trigger the template check and pass with standard `- [x]` marks.

## Summary by Sourcery

Fix the PR template checklist CI workflow to correctly recognize completed items and bump the project version to 0.4.0-beta.20.

Bug Fixes:
- Correct the checklist regex in the PR template check so standard `[x]` and `[X]` marks are treated as completed rather than unchecked.

Enhancements:
- Update version metadata across manifest, package files, tests, and changelog for release 0.4.0-beta.20.

Documentation:
- Add changelog entry describing the fix to the PR template checklist behavior.

Tests:
- Adjust CLI help and release metadata tests to assert the new 0.4.0-beta.20 version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pull request checklist validation now recognizes both lowercase and uppercase `x` markers as completed.

* **Release**
  * Updated the release to version `0.4.0-beta.20`.
  * Added changelog details for the checklist validation fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->