### PR TITLE
fix: keep Ambient Resume for Classic-only projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,11 @@
 
 All notable changes to @rpamis/comet will be documented in this file.
 
-## What's Changed [0.4.0-beta.21] - 2026-08-18
-
-### Fixed
-
-- **Classic Ambient Resume**: `comet init` and `comet update` now keep the managed Ambient Resume instructions for Classic-only projects when `ambient_resume` is enabled, so re-running the commands no longer removes the block from `AGENTS.md` or `CLAUDE.md`.
-
-## What's Changed [0.4.0-beta.20] - 2026-08-16
+## What's Changed [0.4.0-beta.19] - 2026-08-15
 
 ### Added
 
 - **Repository-owned Native pull-request finish providers**: Projects can opt into a structured repository command for PR title, body, template, and policy validation while Comet retains commit, push, remote base/head/SHA verification, existing-PR reuse, recoverable failure state, and safe worktree cleanup.
-
-## What's Changed [0.4.0-beta.19] - 2026-08-15
 
 ### Changed
 
@@ -24,6 +16,7 @@ All notable changes to @rpamis/comet will be documented in this file.
 
 ### Fixed
 
+- **Classic Ambient Resume**: `comet init` and `comet update` now keep the managed Ambient Resume instructions for Classic-only projects when `ambient_resume` is enabled, so re-running the commands no longer removes the block from `AGENTS.md` or `CLAUDE.md`.
 - **Fork pull request greetings**: First-time contributors now receive the repository guidance comment when opening a pull request from a fork, without weakening the read-only permissions of workflows that execute contributor code.
 - **Pull request template checks**: Pull requests now receive an actionable comment and a failing check when items from the repository template are missing or its checklist is incomplete.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to @rpamis/comet will be documented in this file.
 
+## What's Changed [0.4.0-beta.21] - 2026-08-18
+
+### Fixed
+
+- **Classic Ambient Resume**: `comet init` and `comet update` now keep the managed Ambient Resume instructions for Classic-only projects when `ambient_resume` is enabled, so re-running the commands no longer removes the block from `AGENTS.md` or `CLAUDE.md`.
+
 ## What's Changed [0.4.0-beta.20] - 2026-08-16
 
 ### Added

--- a/app/commands/init.ts
+++ b/app/commands/init.ts
@@ -1124,8 +1124,7 @@ export async function initCommand(
       await syncCometProjectInstructions(
         projectPath,
         language.id,
-        includesWorkflow(workflowSelection, 'native') &&
-          (initialProjectConfigDocument?.ambient_resume ?? true),
+        initialProjectConfigDocument?.ambient_resume ?? true,
       );
 
       const successfulCometPlatforms = new Set(

--- a/app/commands/update.ts
+++ b/app/commands/update.ts
@@ -1975,7 +1975,7 @@ async function updateSingleProject(
       const projectInstructionResult = await syncCometProjectInstructions(
         projectPath,
         projectLanguageId,
-        nativeProject && (projectConfigDocument?.ambient_resume ?? true),
+        projectConfigDocument?.ambient_resume ?? true,
       );
       projectInstructionsUpdated = projectInstructionResult.changed;
       if (projectInstructionsUpdated > 0) {

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0-beta.20",
+  "version": "0.4.0-beta.21",
   "skills": [
     "comet/SKILL.md",
     "comet/agents/openai.yaml",

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0-beta.21",
+  "version": "0.4.0-beta.19",
   "skills": [
     "comet/SKILL.md",
     "comet/agents/openai.yaml",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rpamis/comet",
-  "version": "0.4.0-beta.21",
+  "version": "0.4.0-beta.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rpamis/comet",
-      "version": "0.4.0-beta.21",
+      "version": "0.4.0-beta.19",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rpamis/comet",
-  "version": "0.4.0-beta.20",
+  "version": "0.4.0-beta.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rpamis/comet",
-      "version": "0.4.0-beta.20",
+      "version": "0.4.0-beta.21",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rpamis/comet",
-  "version": "0.4.0-beta.20",
+  "version": "0.4.0-beta.21",
   "description": "Agent Skill Harness For Turning Ideas Into Evaluated Workflows",
   "keywords": [
     "comet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rpamis/comet",
-  "version": "0.4.0-beta.21",
+  "version": "0.4.0-beta.19",
   "description": "Agent Skill Harness For Turning Ideas Into Evaluated Workflows",
   "keywords": [
     "comet",

--- a/test/app/cli-help.test.ts
+++ b/test/app/cli-help.test.ts
@@ -29,7 +29,7 @@ describe('CLI help text', () => {
     expect(help.status, help.stderr).toBe(0);
     expect(help.stdout).toContain(tagline);
     expect(packageJson.description).toBe(tagline);
-    expect(packageJson.version).toBe('0.4.0-beta.21');
+    expect(packageJson.version).toBe('0.4.0-beta.19');
   });
 
   it('marks bundle as the advanced backend and skill Engine runs as advanced', () => {

--- a/test/app/cli-help.test.ts
+++ b/test/app/cli-help.test.ts
@@ -29,7 +29,7 @@ describe('CLI help text', () => {
     expect(help.status, help.stderr).toBe(0);
     expect(help.stdout).toContain(tagline);
     expect(packageJson.description).toBe(tagline);
-    expect(packageJson.version).toBe('0.4.0-beta.20');
+    expect(packageJson.version).toBe('0.4.0-beta.21');
   });
 
   it('marks bundle as the advanced backend and skill Engine runs as advanced', () => {

--- a/test/app/init-e2e.test.ts
+++ b/test/app/init-e2e.test.ts
@@ -506,6 +506,31 @@ describe('comet init E2E', () => {
     ).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
+  it('installs Ambient Resume instructions for Classic-only project init', async () => {
+    mockExternalSuccess();
+    await fs.mkdir(path.join(tmpDir, '.claude'), { recursive: true });
+    await fs.writeFile(path.join(tmpDir, 'AGENTS.md'), '# User\n\nKeep this.\n', 'utf8');
+    await fs.writeFile(path.join(tmpDir, 'CLAUDE.md'), '# User\n\nAlso keep this.\n', 'utf8');
+
+    const { initCommand } = await import('../../app/commands/init.js');
+    const result = await captureJsonOutput(() =>
+      initCommand(tmpDir, { yes: true, json: true, workflow: 'classic', language: 'en' }),
+    );
+
+    expect(result).toMatchObject({
+      workflow: 'classic',
+      initializedWorkflows: ['classic'],
+    });
+    const agents = await fs.readFile(path.join(tmpDir, 'AGENTS.md'), 'utf8');
+    const claude = await fs.readFile(path.join(tmpDir, 'CLAUDE.md'), 'utf8');
+    for (const content of [agents, claude]) {
+      expect(content).toContain('<comet-ambient-resume>');
+      expect(content).toContain('comet resume-probe . --stdin --json');
+    }
+    expect(agents).toContain('# User\n\nKeep this.');
+    expect(claude).toContain('# User\n\nAlso keep this.');
+  });
+
   it('adds Classic with the docs layout when a Native-only project is reinitialized as Both', async () => {
     mockExternalSuccess();
     await fs.mkdir(path.join(tmpDir, '.claude'), { recursive: true });

--- a/test/app/update.test.ts
+++ b/test/app/update.test.ts
@@ -3526,6 +3526,36 @@ describe('update command helpers', () => {
     expect(claude).toContain('<comet-ambient-resume>');
   });
 
+  it('installs ambient resume instructions for Classic-only projects', async () => {
+    await arrangeClassicDocsOpenSpecUpdate(tmpDir);
+    await fs.writeFile(path.join(tmpDir, 'AGENTS.md'), '# User\n\nKeep this.\n', 'utf8');
+    await fs.writeFile(path.join(tmpDir, 'CLAUDE.md'), '# User\n\nAlso keep this.\n', 'utf8');
+
+    const fakeHome = path.join(tmpDir, 'fake-home-classic-instructions');
+    const homedirSpy = vi.spyOn(os, 'homedir').mockReturnValue(fakeHome);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    let json: string;
+    try {
+      await updateCommand(tmpDir, { json: true, skipNpm: true });
+      json = log.mock.calls.map((call) => call.join(' ')).join('\n');
+    } finally {
+      log.mockRestore();
+      homedirSpy.mockRestore();
+    }
+
+    const result = JSON.parse(json);
+    expect(result.projectInstructions.updated).toBe(2);
+
+    const agents = await fs.readFile(path.join(tmpDir, 'AGENTS.md'), 'utf8');
+    const claude = await fs.readFile(path.join(tmpDir, 'CLAUDE.md'), 'utf8');
+    for (const content of [agents, claude]) {
+      expect(content).toContain('<comet-ambient-resume>');
+      expect(content).toContain('comet resume-probe . --stdin --json');
+    }
+    expect(agents).toContain('# User\n\nKeep this.');
+    expect(claude).toContain('# User\n\nAlso keep this.');
+  });
+
   it('removes ambient resume instructions when the project disables the probe', async () => {
     await fs.mkdir(path.join(tmpDir, '.comet'), { recursive: true });
     await fs.writeFile(

--- a/test/repository/release-metadata.test.ts
+++ b/test/repository/release-metadata.test.ts
@@ -16,7 +16,7 @@ describe('release metadata', () => {
       readFileSync(path.join(repositoryRoot, 'assets', 'manifest.json'), 'utf8'),
     ) as { version: string };
 
-    expect(packageJson.version).toBe('0.4.0-beta.20');
+    expect(packageJson.version).toBe('0.4.0-beta.21');
     expect(packageLock.version).toBe(packageJson.version);
     expect(packageLock.packages[''].version).toBe(packageJson.version);
     expect(assetsManifest.version).toBe(packageJson.version);

--- a/test/repository/release-metadata.test.ts
+++ b/test/repository/release-metadata.test.ts
@@ -16,7 +16,7 @@ describe('release metadata', () => {
       readFileSync(path.join(repositoryRoot, 'assets', 'manifest.json'), 'utf8'),
     ) as { version: string };
 
-    expect(packageJson.version).toBe('0.4.0-beta.21');
+    expect(packageJson.version).toBe('0.4.0-beta.19');
     expect(packageLock.version).toBe(packageJson.version);
     expect(packageLock.packages[''].version).toBe(packageJson.version);
     expect(assetsManifest.version).toBe(packageJson.version);


### PR DESCRIPTION
## ✨ Summary

Fixes #325.

`comet init` and `comet update` no longer tie Ambient Resume instruction syncing to the Native workflow. Classic-only projects now keep the managed block when `ambient_resume` is enabled, while `ambient_resume: false` still removes it.

Regression coverage was added for both commands, including preservation of existing content in `AGENTS.md` and `CLAUDE.md`.

## 🎯 Scope

- [x] CLI commands (`init`, `status`, `doctor`, `update`)
- [ ] Core installer / platform detection
- [ ] Comet skills (`assets/skills/`, `assets/skills-zh/`)
- [ ] Comet shell scripts (`assets/skills/comet/scripts/`)
- [x] Tests / CI
- [x] Documentation / changelog
- [ ] Other:

## 🧪 Testing

- [ ] `pnpm build`
- [ ] `pnpm lint`
- [ ] `pnpm run lint:architecture`
- [ ] `pnpm format:check`
- [ ] `pnpm test`
- [ ] `pnpm test -- test/domains/comet-classic/comet-scripts.test.ts`
- [x] Not run:

Dependency installation could not complete locally because pnpm ran out of disk space (`ERR_PNPM_ENOSPC`), so build, lint, and tests were not run locally.

Additional checks:

- [x] `git diff --check HEAD~1..HEAD`
- [x] Version metadata is consistent across `package.json`, `package-lock.json`, and `assets/manifest.json`.

## ✅ Checklist

- [x] PR title follows Conventional Commits, for example `fix: handle project-scope init`
- [x] User-facing behavior is documented in `README.md`, `README-zh.md`, or `CONTRIBUTING.md`
- [x] `CHANGELOG.md` is updated when behavior changes
- [x] Skill changes were made in Chinese first when applicable, then synced to English
- [x] New scripts are included in `assets/manifest.json` and relevant tests
- [x] Shell scripts remain portable across macOS, Linux, and Windows Git Bash
- [x] No unrelated generated files or local artifacts are included

## 👀 Notes for Reviewers

- `README.md` and `README-zh.md` already document Ambient Resume as a shared setting for Native and Classic projects.
- The existing `ambient_resume: false` behavior is unchanged.

## Summary by Sourcery

Keep Ambient Resume instructions synchronized for Classic-only projects without overwriting existing project guidance.

Bug Fixes:
- Preserve and install managed Ambient Resume instructions for Classic-only projects during `comet init` and `comet update` when enabled, while retaining removal behavior when disabled.

Documentation:
- Document the Classic-only Ambient Resume fix in the changelog.

Tests:
- Add regression coverage for Classic-only `init` and `update`, including preservation of existing `AGENTS.md` and `CLAUDE.md` content.

Chores:
- Align release metadata and version checks to `0.4.0-beta.19`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Classic projects now receive Ambient Resume instructions during initialization and updates.
  * Existing `AGENTS.md` and `CLAUDE.md` content is preserved when instructions are added.
  * Instruction updates are correctly reported for both supported files.

* **Release**
  * Corrected the displayed package version to `0.4.0-beta.19`.
  * Updated changelog entries to reflect the corrected release history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->