### PR TITLE
fix: exclude .comet runtime state from eval skill copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to @rpamis/comet will be documented in this file.
 
 - **Repository-owned Native pull-request finish providers**: Projects can opt into a structured repository command for PR title, body, template, and policy validation while Comet retains commit, push, remote base/head/SHA verification, existing-PR reuse, recoverable failure state, and safe worktree cleanup.
 
+### Fixed
+
+- **Windows Eval skill copies**: `comet eval` no longer copies the framework's own `.comet` runtime state into test sandboxes and artifact snapshots, preventing nested-cache `MAX_PATH` failures on Windows.
+
 ## What's Changed [0.4.0-beta.19] - 2026-08-15
 
 ### Changed

--- a/eval/local/tests/conftest.py
+++ b/eval/local/tests/conftest.py
@@ -1499,13 +1499,23 @@ def _snapshot_dynamic_skill_package(test_dir: Path, skill_hints: dict[str, Any])
     snapshot_root = test_dir / "_eval_target_skills"
     snapshot_root.mkdir(parents=True, exist_ok=True)
     package_dest = snapshot_root / package_dir.name
-    shutil.copytree(package_dir, package_dest, dirs_exist_ok=True)
+    shutil.copytree(
+        package_dir,
+        package_dest,
+        dirs_exist_ok=True,
+        ignore=shutil.ignore_patterns(".comet"),
+    )
 
     for node_skill in skill_hints.get("generated_node_skills") or []:
         node_source = package_dir.parent / node_skill
         if not (node_source / "SKILL.md").exists():
             continue
-        shutil.copytree(node_source, snapshot_root / node_skill, dirs_exist_ok=True)
+        shutil.copytree(
+            node_source,
+            snapshot_root / node_skill,
+            dirs_exist_ok=True,
+            ignore=shutil.ignore_patterns(".comet"),
+        )
 
     return str(package_dest.relative_to(test_dir)).replace("\\", "/")
 
@@ -1667,7 +1677,12 @@ def setup_test_context(test_dir):
         skill_dir.mkdir(parents=True, exist_ok=True)
 
         if source_dir and source_dir.is_dir():
-            shutil.copytree(source_dir, skill_dir, dirs_exist_ok=True)
+            shutil.copytree(
+                source_dir,
+                skill_dir,
+                dirs_exist_ok=True,
+                ignore=shutil.ignore_patterns(".comet"),
+            )
 
         shutil.copyfile(skill_file, skill_dir / "SKILL.md")
 

--- a/eval/local/tests/scaffold/test_conftest_helpers.py
+++ b/eval/local/tests/scaffold/test_conftest_helpers.py
@@ -710,6 +710,30 @@ def test_setup_test_context_configures_039_shell_hook(tmp_path: Path, setup_test
     assert command == "bash /workspace/.claude/skills/comet/scripts/comet-hook-guard.sh"
 
 
+def test_setup_test_context_excludes_comet_runtime_state_from_skill_copy(
+    tmp_path: Path, setup_test_context
+):
+    source_dir = tmp_path / "comet-source"
+    source_dir.mkdir()
+    (source_dir / "SKILL.md").write_text("---\nname: comet\n---\n\nOriginal.", encoding="utf-8")
+    runtime_state = source_dir / ".comet" / "eval" / "cache" / "uv"
+    runtime_state.mkdir(parents=True)
+    (runtime_state / "long-wheel.lock").write_text("cached", encoding="utf-8")
+
+    setup_test_context(
+        skills={
+            "comet": {
+                "sections": ["---\nname: comet\n---\n\nGenerated."],
+                "source_dir": source_dir,
+            }
+        }
+    )
+
+    installed = tmp_path / ".claude" / "skills" / "comet"
+    assert (installed / "SKILL.md").exists()
+    assert not (installed / ".comet").exists()
+
+
 def test_codex_guard_uses_codex_hook_config_while_scripts_remain_under_agents(tmp_path: Path):
     command = "node /workspace/.agents/skills/comet/scripts/comet-hook-guard.mjs"
 
@@ -885,6 +909,38 @@ def test_snapshot_dynamic_skill_package_copies_package_and_node_skills(tmp_path:
     assert relative_package == "_eval_target_skills/manifest-skill"
     assert (test_dir / relative_package / "SKILL.md").exists()
     assert (test_dir / "_eval_target_skills" / "manifest-skill-open" / "SKILL.md").exists()
+
+
+def test_snapshot_dynamic_skill_package_excludes_comet_runtime_state(tmp_path: Path):
+    source_root = tmp_path / "source"
+    package = source_root / "manifest-skill"
+    package.mkdir(parents=True)
+    (package / "SKILL.md").write_text("---\nname: manifest-skill\n---\n\nBody.", encoding="utf-8")
+    package_cache = package / ".comet" / "eval" / "cache" / "uv"
+    package_cache.mkdir(parents=True)
+    (package_cache / "long-wheel.lock").write_text("cached", encoding="utf-8")
+    stage = source_root / "manifest-skill-open"
+    stage.mkdir()
+    (stage / "SKILL.md").write_text(
+        "---\nname: manifest-skill-open\n---\n\nStage.", encoding="utf-8"
+    )
+    (stage / ".comet" / "eval" / "runs").mkdir(parents=True)
+    test_dir = tmp_path / "workspace"
+    test_dir.mkdir()
+
+    relative_package = conftest._snapshot_dynamic_skill_package(
+        test_dir,
+        {
+            "path": str(package),
+            "generated_node_skills": ["manifest-skill-open"],
+        },
+    )
+
+    assert (test_dir / relative_package / "SKILL.md").exists()
+    assert not (test_dir / relative_package / ".comet").exists()
+    node_snapshot = test_dir / "_eval_target_skills" / "manifest-skill-open"
+    assert (node_snapshot / "SKILL.md").exists()
+    assert not (node_snapshot / ".comet").exists()
 
 
 def _workflow_overlay_validator():


### PR DESCRIPTION
## ✨ Summary

- Fix `comet eval` failing on Windows during test preparation: skill source directories contain the eval framework's own `.comet` runtime state (uv cache, run artifacts), and copying it into the test sandbox and artifact snapshots nests `.comet` directories until paths overflow Windows MAX_PATH (WinError 3).
- Exclude `.comet` in all three `copytree` call sites: the sandbox skill install (`_write_skill`) and both dynamic skill package snapshot copies (`_snapshot_dynamic_skill_package`).
- This complements #321, which covers only the `_write_skill` site; this PR is the complete fix.

Fixes #336

## 🎯 Scope

- [ ] CLI commands (`init`, `status`, `doctor`, `update`)
- [ ] Core installer / platform detection
- [ ] Comet skills (`assets/skills/`, `assets/skills-zh/`)
- [ ] Comet shell scripts (`assets/skills/comet/scripts/`)
- [x] Tests / CI
- [ ] Documentation / changelog
- [x] Other:

Eval local test framework (`eval/local/tests/conftest.py`).

## 🧪 Testing

- [x] `pnpm build`
- [x] `pnpm lint`
- [x] `pnpm run lint:architecture`
- [ ] `pnpm format:check`
- [x] `pnpm test`
- [x] `pnpm test -- test/domains/comet-classic/comet-scripts.test.ts`
- [ ] Not run:

Local results (Windows 11, Git Bash):

- `uv run pytest local/tests/scaffold/test_conftest_helpers.py` — 49/49 passed, including 2 new regression tests covering `.comet` exclusion in both the sandbox skill install and the artifact snapshot copies. Negative verification: with the `conftest.py` fix reverted, both new tests fail as expected.
- `pnpm test` — 3766/3771 passed. The 5 failures are local-environment issues unrelated to this change and were verified as such: `eval-static-collect.integration.test.ts` (2) fails on this machine's npm rejecting `--allow-scripts` (EALLOWSCRIPTS); `comet-scripts.test.ts` (3) passes 221/221 with a clean `HOME`, the failures come from a global `~/.comet` config (`language: zh-CN`) leaking into the test environment.
- `pnpm format:check` — all files touched by this PR pass. The 5 warnings are CRLF false positives on untouched dashboard files caused by `core.autocrlf=true` on Windows (a known local-only issue per AGENTS.md); Linux CI is unaffected.

## ✅ Checklist

- [x] PR title follows Conventional Commits, for example `fix: handle project-scope init`
- [x] User-facing behavior is documented in `README.md`, `README-zh.md`, or `CONTRIBUTING.md`
- [x] `CHANGELOG.md` is updated when behavior changes
- [x] Skill changes were made in Chinese first when applicable, then synced to English
- [x] New scripts are included in `assets/manifest.json` and relevant tests
- [x] Shell scripts remain portable across macOS, Linux, and Windows Git Bash
- [x] No unrelated generated files or local artifacts are included

## 👀 Notes for Reviewers

#321 fixed only the `_write_skill` copy site; the two snapshot copies in `_snapshot_dynamic_skill_package` still pull `.comet` caches into run artifacts, which is the failure path reported in #336's follow-up comment. This PR covers all three sites, so #321 can drop its `conftest.py` hunk when it rebases.

## Summary by Sourcery

Exclude evaluation runtime state from all skill copies to prevent Windows path-length failures during test preparation.

Bug Fixes:
- Prevent `comet eval` from copying `.comet` runtime state into skill sandboxes and artifact snapshots, avoiding nested-cache path failures on Windows.

Tests:
- Add regression coverage for excluding `.comet` state from installed skills and dynamic skill package snapshots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - `comet init` and `comet update` now preserve managed Ambient Resume instructions for Classic-only projects when Ambient Resume is enabled.
  - Test workspace snapshots now exclude internal runtime state while retaining required skill files and generated skills.

- **Documentation**
  - Updated the beta release date and consolidated related fixes under the correct release entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->