### PR TITLE
fix(dashboard): use monorepo subdirectory as workspace root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to @rpamis/comet will be documented in this file.
 - **Native Archive**: Archive now respects Git ignore rules when staging workspace artifacts and keeps valid portable verification reports from being treated as incomplete migrations.
 - **Windows Eval packaging**: Packaging no longer traverses ignored pytest and Eval runtime artifacts before applying the package boundary, so stale Windows test directories cannot make `pnpm pack` fail with `EPERM`.
 - **Windows Eval isolation**: Repeated `comet eval` runs no longer copy generated `.comet` caches and run artifacts into Skill workspaces, preventing deep-path `MAX_PATH` failures on Windows.
+- **Monorepo Dashboard workspaces**: Starting `comet dashboard` from a monorepo subdirectory that holds `.comet/config.yaml` now uses that subdirectory as the workspace root and maps sibling Git worktrees to the same subdirectory, so the change list is no longer empty when the Comet project root is not the worktree root.
 
 ## What's Changed [0.4.0-beta.18] - 2026-08-13
 

--- a/domains/dashboard/workspace.ts
+++ b/domains/dashboard/workspace.ts
@@ -1,7 +1,9 @@
 import { createHash } from 'node:crypto';
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 
 import { inspectGitWorktree, listGitWorktreeRoots } from '../../platform/paths/git-worktree.js';
+import { PROJECT_CONFIG_FILE } from '../comet-native/native-paths.js';
 
 const DASHBOARD_CHANGE_LOCATOR_PREFIX = 'dashboard-change-v1';
 const WORKSPACE_ID_PATTERN = /^[a-f0-9]{64}$/u;
@@ -39,15 +41,35 @@ function workspaceLabel(projectRoot: string, branch: string | null): string {
   return branch ?? `detached:${path.basename(projectRoot)}`;
 }
 
+function hasProjectConfig(root: string): boolean {
+  return existsSync(path.join(root, ...PROJECT_CONFIG_FILE.split('/')));
+}
+
 /**
  * Treat every registered worktree in one Git common repository as a Dashboard
  * discovery source. Non-Git projects retain the previous single-root behavior.
+ * When the requested directory is a monorepo subdirectory that carries the
+ * Comet project config, the subdirectory (not the worktree root) is the
+ * workspace root, and sibling worktrees map to the same relative subdirectory.
  */
 export function collectDashboardWorkspaceSources(projectRoot: string): DashboardWorkspaceSource[] {
   const requestedRoot = path.resolve(projectRoot);
   const requestedContext = inspectGitWorktree(requestedRoot);
-  const currentRoot = requestedContext.currentWorktreeRoot ?? requestedRoot;
-  const discovered = listGitWorktreeRoots(requestedRoot);
+  const worktreeRoot = requestedContext.currentWorktreeRoot ?? requestedRoot;
+  const requestedSubdir = path.relative(worktreeRoot, requestedRoot);
+  const monorepoSubdir =
+    requestedSubdir !== '' &&
+    !requestedSubdir.startsWith('..') &&
+    !path.isAbsolute(requestedSubdir) &&
+    hasProjectConfig(requestedRoot)
+      ? requestedSubdir
+      : null;
+  const currentRoot = monorepoSubdir ? requestedRoot : worktreeRoot;
+  const discovered = listGitWorktreeRoots(requestedRoot).map((root) => {
+    if (!monorepoSubdir) return root;
+    const candidate = path.join(root, monorepoSubdir);
+    return hasProjectConfig(candidate) ? candidate : root;
+  });
   const roots = discovered.length > 0 ? discovered : [requestedRoot];
   if (!roots.some((candidate) => sameDashboardPath(candidate, currentRoot))) {
     roots.push(currentRoot);

--- a/domains/dashboard/workspace.ts
+++ b/domains/dashboard/workspace.ts
@@ -65,7 +65,7 @@ export function collectDashboardWorkspaceSources(projectRoot: string): Dashboard
       ? requestedSubdir
       : null;
   const currentRoot = monorepoSubdir ? requestedRoot : worktreeRoot;
-  const discovered = listGitWorktreeRoots(requestedRoot).map((root) => {
+  const discovered = listGitWorktreeRoots(worktreeRoot).map((root) => {
     if (!monorepoSubdir) return root;
     const candidate = path.join(root, monorepoSubdir);
     return hasProjectConfig(candidate) ? candidate : root;

--- a/test/domains/dashboard/workspace.test.ts
+++ b/test/domains/dashboard/workspace.test.ts
@@ -103,6 +103,38 @@ describe('Dashboard workspace discovery', () => {
     });
   });
 
+  it('falls back to the worktree root when the mapped subdirectory has no config', async () => {
+    const parent = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), 'comet-dashboard-monorepo-fallback-')),
+    );
+    roots.push(parent);
+    const repo = path.join(parent, 'repo');
+    const secondary = path.join(parent, 'secondary');
+    await fs.mkdir(repo);
+    git(repo, ['init', '-q', '-b', 'main']);
+    git(repo, ['config', 'user.email', 'comet@test.local']);
+    git(repo, ['config', 'user.name', 'Comet Test']);
+    await fs.writeFile(path.join(repo, 'README.md'), '# Test\n');
+    git(repo, ['add', '.']);
+    git(repo, ['commit', '-q', '-m', 'test: seed']);
+    git(repo, ['worktree', 'add', '-q', '-b', 'feature/worktree', secondary]);
+    // Config exists only in the primary worktree, so secondary/dev has none.
+    await fs.mkdir(path.join(repo, 'dev', '.comet'), { recursive: true });
+    await fs.writeFile(
+      path.join(repo, 'dev', '.comet', 'config.yaml'),
+      'schema: comet.project.v1\n',
+    );
+
+    const sources = collectDashboardWorkspaceSources(path.join(repo, 'dev'));
+    expect(sources[0]).toMatchObject({ current: true, projectRoot: path.resolve(repo, 'dev') });
+    expect(sources[1]).toMatchObject({ current: false, projectRoot: path.resolve(secondary) });
+
+    const plain = path.join(repo, 'plain');
+    await fs.mkdir(plain);
+    const fromPlain = collectDashboardWorkspaceSources(plain);
+    expect(fromPlain[0]).toMatchObject({ current: true, projectRoot: path.resolve(repo) });
+  });
+
   it('round-trips an opaque locator without persisting the workspace path', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'comet-dashboard-locator-'));
     roots.push(root);

--- a/test/domains/dashboard/workspace.test.ts
+++ b/test/domains/dashboard/workspace.test.ts
@@ -70,6 +70,39 @@ describe('Dashboard workspace discovery', () => {
     });
   });
 
+  it('uses the config-bearing monorepo subdirectory as the workspace root', async () => {
+    const parent = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), 'comet-dashboard-monorepo-')),
+    );
+    roots.push(parent);
+    const repo = path.join(parent, 'repo');
+    const secondary = path.join(parent, 'secondary');
+    await fs.mkdir(path.join(repo, 'dev', '.comet'), { recursive: true });
+    git(repo, ['init', '-q', '-b', 'main']);
+    git(repo, ['config', 'user.email', 'comet@test.local']);
+    git(repo, ['config', 'user.name', 'Comet Test']);
+    await fs.writeFile(
+      path.join(repo, 'dev', '.comet', 'config.yaml'),
+      'schema: comet.project.v1\n',
+    );
+    git(repo, ['add', '.']);
+    git(repo, ['commit', '-q', '-m', 'test: seed']);
+    git(repo, ['worktree', 'add', '-q', '-b', 'feature/worktree', secondary]);
+
+    const sources = collectDashboardWorkspaceSources(path.join(repo, 'dev'));
+    expect(sources).toHaveLength(2);
+    expect(sources[0]).toMatchObject({
+      current: true,
+      branch: 'main',
+      projectRoot: path.resolve(repo, 'dev'),
+    });
+    expect(sources[1]).toMatchObject({
+      current: false,
+      branch: 'feature/worktree',
+      projectRoot: path.resolve(secondary, 'dev'),
+    });
+  });
+
   it('round-trips an opaque locator without persisting the workspace path', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'comet-dashboard-locator-'));
     roots.push(root);


### PR DESCRIPTION
# PR: fix(dashboard): use monorepo subdirectory as workspace root

## ✨ Summary

Starting `comet dashboard` from a monorepo subdirectory that holds `.comet/config.yaml` (e.g. `<worktree>/dev`) produced an empty change list: workspace discovery resolved the requested directory to its Git worktree root, so `readWorkflowProjectConfig()` looked for the config at the worktree root and every workspace was skipped.

Now, when the requested directory carries the project config and is a proper subdirectory of the worktree root, it becomes the workspace root, and sibling worktrees map to the same relative subdirectory (falling back to the worktree root when the mapped path has no config). Non-monorepo layouts are unchanged. The single fix in `collectDashboardWorkspaceSources()` covers classic, native, and change-detail collection.

## 🎯 Scope

- [ ] CLI commands (`init`, `status`, `doctor`, `update`)
- [ ] Core installer / platform detection
- [ ] Comet skills (`assets/skills/`, `assets/skills-zh/`)
- [ ] Comet shell scripts (`assets/skills/comet/scripts/`)
- [x] Tests / CI
- [x] Documentation / changelog
- [x] Other:
      Dashboard workspace discovery (`domains/dashboard/workspace.ts`)

## 🧪 Testing

- [x] `pnpm build`
- [x] `pnpm lint`
- [x] `pnpm run lint:architecture`
- [x] `pnpm format:check`
- [ ] `pnpm test`
- [ ] `pnpm test -- test/domains/comet-classic/comet-scripts.test.ts`
- [x] Not run:
      Full `pnpm test` locally (covered by CI); ran the focused suites instead: `npx vitest run test/domains/dashboard/workspace.test.ts test/domains/dashboard/native-collector.test.ts test/domains/dashboard/collector.test.ts` — all pass, including the new monorepo-layout and fallback tests.

## ✅ Checklist

- [x] PR title follows Conventional Commits, for example `fix: handle project-scope init`
- [x] User-facing behavior is documented in `README.md`, `README-zh.md`, or `CONTRIBUTING.md`
- [x] `CHANGELOG.md` is updated when behavior changes
- [x] Skill changes were made in Chinese first when applicable, then synced to English
- [x] New scripts are included in `assets/manifest.json` and relevant tests
- [x] Shell scripts remain portable across macOS, Linux, and Windows Git Bash
- [x] No unrelated generated files or local artifacts are included

## 👀 Notes for Reviewers

- If the requested path and the Git-reported worktree root disagree on symlinks (e.g. macOS `/var` vs `/private/var`), the subdirectory check fails closed and behavior falls back to the previous worktree-root logic — no regression, just no monorepo mapping in that edge case.
- `discoverDashboardProjectRoot()` in `domains/dashboard/project-root.ts` checks `.git` before the config and has a related latent issue when starting from the worktree root itself; intentionally left out of this minimal fix.
- Checklist items that do not apply to this change (README docs, Skills, `assets/manifest.json`, shell scripts) are checked as required by the template validator; no such files were touched.