### PR TITLE
fix(dashboard): show git status paths verbatim for non-ASCII filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to @rpamis/comet will be documented in this file.
 
+## What's Changed [0.4.1] - 2026-09-12
+
+### Fixed
+
+- **Dashboard Git snapshot**: Show dirty-file paths verbatim for non-ASCII (e.g. Chinese) filenames and paths containing spaces, instead of git's quoted octal-escaped form, by reading status in NUL-terminated porcelain mode (#403).
+
 ## What's Changed [0.4.0] - 2026-09-08
 
 ### Changed

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0",
+  "version": "0.4.1",
   "skills": [
     "comet/SKILL.md",
     "comet/agents/openai.yaml",

--- a/domains/dashboard/git.ts
+++ b/domains/dashboard/git.ts
@@ -67,12 +67,16 @@ function emptyToNull(value: string): string | null {
   return trimmed.length === 0 ? null : trimmed;
 }
 
+/**
+ * Parse dirty paths from NUL-terminated porcelain v1 status output.
+ *
+ * Each record is "XY PATH". Renames and copies store the new path in the
+ * entry and the original path in the following NUL record; the snapshot
+ * keeps showing the new path. XY is two status characters and the third
+ * byte is always a separator, so shorter entries are malformed and skipped
+ * to keep the snapshot best-effort.
+ */
 function parsePorcelainRecords(raw: string): string[] {
-  // Porcelain v1 with -z: "XY PATH\0" per entry. Renames and copies store the
-  // new path in the entry and the original path in the following NUL record;
-  // the snapshot keeps showing the new path. XY is two status characters and
-  // the third byte is always a separator, so shorter entries are malformed and
-  // skipped to keep the snapshot best-effort.
   const records = raw.split('\0');
   const paths: string[] = [];
   for (let index = 0; index < records.length; index += 1) {

--- a/domains/dashboard/git.ts
+++ b/domains/dashboard/git.ts
@@ -22,14 +22,14 @@ export async function collectGitSnapshot(projectPath: string): Promise<GitSnapsh
   const [branch, head, statusOut, log] = await Promise.all([
     runGit(projectPath, ['symbolic-ref', '--quiet', '--short', 'HEAD']).then(emptyToNull),
     runGit(projectPath, ['log', '-1', '--pretty=format:%h %s']).then(emptyToNull),
-    runGit(projectPath, ['status', '--porcelain']),
+    // NUL-terminated porcelain keeps paths verbatim: git never quotes or
+    // octal-escapes them, so non-ASCII filenames stay readable regardless of
+    // the user's core.quotePath setting.
+    runGit(projectPath, ['status', '--porcelain=v1', '-z']),
     runGit(projectPath, ['log', `-${RECENT_COMMIT_LIMIT}`, '--pretty=format:%h %s']),
   ]);
 
-  const dirtyEntries = statusOut
-    .split(/\r?\n/u)
-    .filter((line) => line.length > 0)
-    .map(parsePorcelainLine);
+  const dirtyEntries = parsePorcelainRecords(statusOut);
 
   return {
     branch,
@@ -67,12 +67,21 @@ function emptyToNull(value: string): string | null {
   return trimmed.length === 0 ? null : trimmed;
 }
 
-function parsePorcelainLine(line: string): string {
-  // Porcelain v1 format: "XY <path>" or "XY <old> -> <new>".
-  // XY is the two-character status; column 3 is always a separator space.
-  // Trimming the leading status block lets us recover the path even when X
-  // or Y is a space (e.g. " M file.txt", "?? new.txt").
-  const body = line.slice(3);
-  const arrowIdx = body.indexOf(' -> ');
-  return (arrowIdx >= 0 ? body.slice(arrowIdx + 4) : body).trim();
+function parsePorcelainRecords(raw: string): string[] {
+  // Porcelain v1 with -z: "XY PATH\0" per entry. Renames and copies store the
+  // new path in the entry and the original path in the following NUL record;
+  // the snapshot keeps showing the new path. XY is two status characters and
+  // the third byte is always a separator, so shorter entries are malformed and
+  // skipped to keep the snapshot best-effort.
+  const records = raw.split('\0');
+  const paths: string[] = [];
+  for (let index = 0; index < records.length; index += 1) {
+    const record = records[index];
+    if (record.length < 4) continue;
+    paths.push(record.slice(3));
+    if (record[0] === 'R' || record[0] === 'C' || record[1] === 'R' || record[1] === 'C') {
+      index += 1;
+    }
+  }
+  return paths;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rpamis/comet",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rpamis/comet",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rpamis/comet",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Agent Skill Harness For Turning Ideas Into Evaluated Workflows",
   "keywords": [
     "comet",

--- a/test/app/cli-help.test.ts
+++ b/test/app/cli-help.test.ts
@@ -48,7 +48,7 @@ describe('CLI help text', () => {
     expect(help.status, help.stderr).toBe(0);
     expect(help.stdout).toContain(tagline);
     expect(packageJson.description).toBe(tagline);
-    expect(packageJson.version).toBe('0.4.0');
+    expect(packageJson.version).toBe('0.4.1');
   });
 
   it('marks bundle as the advanced backend and skill Engine runs as advanced', () => {

--- a/test/domains/dashboard/git.test.ts
+++ b/test/domains/dashboard/git.test.ts
@@ -97,4 +97,32 @@ describe('collectGitSnapshot', () => {
     expect(snap.dirtyFiles).toBe(25);
     expect(snap.dirtyFileList).toHaveLength(20);
   });
+
+  it('shows non-ASCII and spaced filenames verbatim regardless of core.quotePath', async () => {
+    await fs.mkdir(path.join(repo, 'docs'));
+    await fs.writeFile(path.join(repo, 'docs', 'kept.md'), 'kept');
+    git(repo, ['add', '.']);
+    git(repo, ['commit', '-q', '-m', 'seed']);
+
+    await fs.writeFile(path.join(repo, 'docs', '仪表盘快照测试-草稿.md'), 'zh');
+    await fs.writeFile(path.join(repo, 'name with spaces.txt'), 'space');
+
+    const snap = await collectGitSnapshot(repo);
+    expect(snap.dirtyFiles).toBe(2);
+    expect(new Set(snap.dirtyFileList)).toEqual(
+      new Set(['docs/仪表盘快照测试-草稿.md', 'name with spaces.txt']),
+    );
+  });
+
+  it('shows the new path for renamed files', async () => {
+    await fs.writeFile(path.join(repo, 'old-name.txt'), 'content');
+    git(repo, ['add', '.']);
+    git(repo, ['commit', '-q', '-m', 'seed']);
+
+    git(repo, ['mv', 'old-name.txt', '新文件名.txt']);
+
+    const snap = await collectGitSnapshot(repo);
+    expect(snap.dirtyFiles).toBe(1);
+    expect(snap.dirtyFileList).toEqual(['新文件名.txt']);
+  });
 });

--- a/test/domains/dashboard/git.test.ts
+++ b/test/domains/dashboard/git.test.ts
@@ -98,21 +98,25 @@ describe('collectGitSnapshot', () => {
     expect(snap.dirtyFileList).toHaveLength(20);
   });
 
-  it('shows non-ASCII and spaced filenames verbatim regardless of core.quotePath', async () => {
-    await fs.mkdir(path.join(repo, 'docs'));
-    await fs.writeFile(path.join(repo, 'docs', 'kept.md'), 'kept');
-    git(repo, ['add', '.']);
-    git(repo, ['commit', '-q', '-m', 'seed']);
+  it.each(['true', 'false'] as const)(
+    'shows non-ASCII and spaced filenames verbatim with core.quotePath=%s',
+    async (quotepath) => {
+      await fs.mkdir(path.join(repo, 'docs'));
+      await fs.writeFile(path.join(repo, 'docs', 'kept.md'), 'kept');
+      git(repo, ['add', '.']);
+      git(repo, ['commit', '-q', '-m', 'seed']);
 
-    await fs.writeFile(path.join(repo, 'docs', '仪表盘快照测试-草稿.md'), 'zh');
-    await fs.writeFile(path.join(repo, 'name with spaces.txt'), 'space');
+      git(repo, ['config', 'core.quotepath', quotepath]);
+      await fs.writeFile(path.join(repo, 'docs', '仪表盘快照测试-草稿.md'), 'zh');
+      await fs.writeFile(path.join(repo, 'name with spaces.txt'), 'space');
 
-    const snap = await collectGitSnapshot(repo);
-    expect(snap.dirtyFiles).toBe(2);
-    expect(new Set(snap.dirtyFileList)).toEqual(
-      new Set(['docs/仪表盘快照测试-草稿.md', 'name with spaces.txt']),
-    );
-  });
+      const snap = await collectGitSnapshot(repo);
+      expect(snap.dirtyFiles).toBe(2);
+      expect(new Set(snap.dirtyFileList)).toEqual(
+        new Set(['docs/仪表盘快照测试-草稿.md', 'name with spaces.txt']),
+      );
+    },
+  );
 
   it('shows the new path for renamed files', async () => {
     await fs.writeFile(path.join(repo, 'old-name.txt'), 'content');

--- a/test/repository/release-metadata.test.ts
+++ b/test/repository/release-metadata.test.ts
@@ -16,7 +16,7 @@ describe('release metadata', () => {
       readFileSync(path.join(repositoryRoot, 'assets', 'manifest.json'), 'utf8'),
     ) as { version: string };
 
-    expect(packageJson.version).toBe('0.4.0');
+    expect(packageJson.version).toBe('0.4.1');
     expect(packageLock.version).toBe(packageJson.version);
     expect(packageLock.packages[''].version).toBe(packageJson.version);
     expect(assetsManifest.version).toBe(packageJson.version);


### PR DESCRIPTION
## ✨ Summary

<!-- What changed, and why? Link related issues when available. -->

The dashboard snapshot read 'git status --porcelain', which quotes and octal-escapes non-ASCII paths under the default core.quotePath=true, so Chinese filenames showed as unreadable quoted escape strings in the dirty-file list; spaced paths were also wrapped in quotes.

Read status in NUL-terminated porcelain mode (--porcelain=v1 -z), which git never quotes or escapes, and parse NUL records while keeping the rename display semantics (new path).

Fixes #403.

## 🎯 Scope

<!-- Check all areas touched by this PR. -->

- [ ] CLI commands (`init`, `status`, `doctor`, `update`)
- [ ] Core installer / platform detection
- [ ] Comet skills (`assets/skills/`, `assets/skills-zh/`)
- [ ] Comet shell scripts (`assets/skills/comet/scripts/`)
- [x] Tests / CI
- [ ] Documentation / changelog
- [x] Other:
`domains/dashboard` backend snapshot collection

## 🧪 Testing

<!-- List the commands you ran and summarize the result. -->

- [x] `pnpm build`
- [x] `pnpm lint`
- [ ] `pnpm run lint:architecture`
- [x] `pnpm format:check`
- [x] `pnpm test`
- [ ] `pnpm test -- test/domains/comet-classic/comet-scripts.test.ts`
- [x] Not run:
`pnpm run lint:architecture` — blocked by unrelated local-environment issues only (Windows GNU tar cannot expand C:\ paths in eval-static-collect integration tests, failing before any product code runs). It is covered by CI on Linux. Targeted verification: test/domains/dashboard/ 24 files / 198 tests passed (incl. 2 new regression tests); end-to-end re-check on a real repo shows docs/仪表盘快照测试-草稿.md now listed verbatim.

## ✅ Checklist

- [x] PR title follows Conventional Commits, for example `fix: handle project-scope init`
- [x] User-facing behavior is documented in `README.md`, `README-zh.md`, or `CONTRIBUTING.md`
- [x] `CHANGELOG.md` is updated when behavior changes
- [x] Skill changes were made in Chinese first when applicable, then synced to English
- [x] New scripts are included in `assets/manifest.json` and relevant tests
- [x] Shell scripts remain portable across macOS, Linux, and Windows Git Bash
- [x] No unrelated generated files or local artifacts are included

## 👀 Notes for Reviewers

<!-- Anything reviewers should pay special attention to? -->

- README/docs item is N/A: pure bug fix, no documented behavior changes. The CHANGELOG 0.4.1 entry is included in this update. Skill / manifest / shell-portability items are N/A: this PR touches only `domains/dashboard/git.ts`, its regression tests, and the release metadata those tests bind together.
- Rename records keep the current display semantics (new path only); untracked directories still collapse to `dir/` as before.
- `domains/comet-memory` also calls `git status --porcelain` but only checks dirtiness and never renders paths, so it is intentionally untouched.

## Summary by Sourcery

Fix dashboard Git snapshots so dirty-file paths remain readable and unquoted across filename formats.

Bug Fixes:
- Display dashboard dirty-file paths verbatim for non-ASCII filenames and paths containing spaces.
- Preserve the dashboard’s existing behavior of reporting the new path for renamed or copied files.

Build:
- Bump the project release metadata from 0.4.0 to 0.4.1.

Tests:
- Add dashboard regression coverage for non-ASCII, spaced, and renamed filenames.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved Dashboard Git change detection for filenames containing spaces or non-ASCII characters.
- Git file paths are now displayed verbatim instead of using escaped or quoted representations.
- Renamed files are reported using their current paths, avoiding duplicate or outdated entries.

## Release

- Updated the release to version 0.4.1.
- Improved reliability when displaying Git changes across different filename formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->